### PR TITLE
MeetingRequest UID attribute optional

### DIFF
--- a/lib/Horde/ActiveSync/Message/MeetingRequest.php
+++ b/lib/Horde/ActiveSync/Message/MeetingRequest.php
@@ -191,7 +191,7 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
         } catch (Horde_Icalendar_Exception $e) {}
 
         try {
-            $this->globalobjid = Horde_Mapi::createGoid($vevent->getAttribute('UID'));
+            $this->globalobjid = Horde_Mapi::createGoid($vevent->getAttributeDefault('UID', 'nouid'));
             $this->starttime = new Horde_Date($vevent->getAttribute('DTSTART'));
         } catch (Horde_Exception $e) {
             throw new Horde_ActiveSync_Exception($e);


### PR DESCRIPTION
If an email has a meeting request (.ics file) as an attachment that doesn't have the `UID` attribute, the activesync sync process will skip this email because of the exception that is thrown.

Instead the `UID` attribute should be optional here.
In my tests it was no problem to replace it with a generic one.