### PR TITLE
Activesync fixes

### DIFF
--- a/lib/Horde/ActiveSync/Imap/Adapter.php
+++ b/lib/Horde/ActiveSync/Imap/Adapter.php
@@ -909,55 +909,67 @@ class Horde_ActiveSync_Imap_Adapter
     {
         $imap_query = new Horde_Imap_Client_Search_Query();
         $imap_query->charset('UTF-8', false);
-        $mboxes = array();
-        $results = array();
+        $mboxes = [];
+        $results = [];
+
+        if ($query) {
+            $q = $query[0];
+            if (($q['op'] ?? '') === Horde_ActiveSync_Request_Search::SEARCH_AND) {
+                if (count($query) !== 1) {
+                    //TODO: Instead report status 8 Horde_ActiveSync_Request_Search::STORE_STATUS_COMPLEX
+                    throw new Horde_ActiveSync_Exception('Multiple AND elements are not supported.');
+                }
+            }
+            $query = [ $q['value'] ];
+        }
+
         foreach ($query as $q) {
-            switch ($q['op']) {
-            case Horde_ActiveSync_Request_Search::SEARCH_AND:
-                return $this->_doQuery(array($q['value']), $range);
-            default:
-                foreach ($q as $key => $value) {
-                    switch ($key) {
-                    case 'FolderType':
-                        if ($value != Horde_ActiveSync::CLASS_EMAIL) {
-                            throw new Horde_ActiveSync_Exception('Only Email folders are supported.');
-                        }
-                        break;
-                    case 'serverid':
-                        $mboxes[] = new Horde_Imap_Client_Mailbox($value);
-                        break;
-                    case Horde_ActiveSync_Message_Mail::POOMMAIL_DATERECEIVED:
-                        if ($q['op'] == Horde_ActiveSync_Request_Search::SEARCH_GREATERTHAN) {
-                            $query_range = Horde_Imap_Client_Search_Query::DATE_SINCE;
-                        } elseif ($q['op'] == Horde_ActiveSync_Request_Search::SEARCH_LESSTHAN) {
-                            $query_range = Horde_Imap_Client_Search_Query::DATE_BEFORE;
-                        } else {
-                            $query_range = Horde_Imap_Client_Search_Query::DATE_ON;
-                        }
-                        $imap_query->dateSearch($value, $query_range);
-                        break;
-                    case Horde_ActiveSync_Request_Search::SEARCH_FREETEXT:
-                        $imap_query->text($value, false);
-                        break;
-                    case 'subquery':
-                        $imap_query->andSearch(array($this->_buildSubQuery($value)));
+            $op = $q['op'] ?? '';
+            foreach ($q as $key => $value) {
+                switch ($key) {
+                case 'FolderType':
+                    if ($value !== Horde_ActiveSync::CLASS_EMAIL) {
+                        throw new Horde_ActiveSync_Exception('Only Email folders are supported.');
                     }
+                    break;
+                case 'serverid':
+                    $mboxes[] = new Horde_Imap_Client_Mailbox($value);
+                    break;
+                case Horde_ActiveSync_Message_Mail::POOMMAIL_DATERECEIVED:
+                    if ($op == Horde_ActiveSync_Request_Search::SEARCH_GREATERTHAN) {
+                        $query_range = Horde_Imap_Client_Search_Query::DATE_SINCE;
+                    } elseif ($op == Horde_ActiveSync_Request_Search::SEARCH_LESSTHAN) {
+                        $query_range = Horde_Imap_Client_Search_Query::DATE_BEFORE;
+                    } else {
+                        $query_range = Horde_Imap_Client_Search_Query::DATE_ON;
+                    }
+                    $imap_query->dateSearch($value, $query_range);
+                    break;
+                case Horde_ActiveSync_Request_Search::SEARCH_FREETEXT:
+                    $imap_query->text($value, false);
+                    break;
+                case 'subquery':
+                    $imap_query->andSearch(array($this->_buildSubQuery($value)));
+                    break;
                 }
             }
         }
-        if (empty($mboxes)) {
+
+        if (!$mboxes) {
             foreach ($this->getMailboxes() as $mailbox) {
                 $mboxes[] = $mailbox['ob'];
             }
         }
+
         foreach ($mboxes as $mbox) {
             try {
                 $search_res = $this->_getImapOb()->search(
                     $mbox,
                     $imap_query,
-                    array(
-                        'results' => array(Horde_Imap_Client::SEARCH_RESULTS_MATCH, Horde_Imap_Client::SEARCH_RESULTS_SAVE, Horde_Imap_Client::SEARCH_RESULTS_COUNT),
-                        'sort' => array(Horde_Imap_Client::SORT_REVERSE, Horde_Imap_Client::SORT_ARRIVAL))
+                    [
+                        'results' => [ Horde_Imap_Client::SEARCH_RESULTS_MATCH, Horde_Imap_Client::SEARCH_RESULTS_SAVE, Horde_Imap_Client::SEARCH_RESULTS_COUNT ],
+                        'sort' => [ Horde_Imap_Client::SORT_REVERSE, Horde_Imap_Client::SORT_ARRIVAL ]
+                    ]
                 );
             } catch (Horde_Imap_Client_Exception $e) {
                 throw new Horde_ActiveSync_Exception($e);
@@ -968,12 +980,7 @@ class Horde_ActiveSync_Imap_Adapter
 
             $ids = $search_res['match']->ids;
             foreach ($ids as $id) {
-                $results[] = array('uniqueid' => $mbox->utf8 . ':' . $id, 'searchfolderid' => $mbox->utf8);
-            }
-            if (!empty($range)) {
-                preg_match('/(.*)\-(.*)/', $range, $matches);
-                $return_count = $matches[2] - $matches[1];
-                $results = array_slice($results, $matches[1], $return_count + 1, true);
+                $results[] = [ 'uniqueid' => $mbox->utf8 . ':' . $id, 'searchfolderid' => $mbox->utf8 ];
             }
         }
 

--- a/lib/Horde/ActiveSync/Message/Base.php
+++ b/lib/Horde/ActiveSync/Message/Base.php
@@ -215,7 +215,7 @@ class Horde_ActiveSync_Message_Base
      * @return mixed  The value of the requested property.
      * @todo: Return boolean false if not set. Not BC to change it.
      */
-    public function &__get($property)
+    public function __get($property)
     {
         return $this->_getAttribute($property, '');
     }

--- a/lib/Horde/ActiveSync/Request/Search.php
+++ b/lib/Horde/ActiveSync/Request/Search.php
@@ -82,6 +82,7 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
     const STORE_STATUS_CONNECTIONERR = 7;
     const STORE_STATUS_COMPLEX       = 8;
     const STORE_STATUS_FOLDERSYNC    = 11;
+    const STORE_STATUS_RANGEERR      = 12;
 
     /**
      * @var Horde_ActiveSync_Collections
@@ -95,6 +96,8 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
      */
     protected function _handle()
     {
+        // See https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-ascmd/8211179b-14f3-44ab-9de6-b69ca2a48c4e
+
         $this->_logger->meta('Handling SEARCH command.');
         $search_status = self::SEARCH_STATUS_SUCCESS;
         $store_status = self::STORE_STATUS_SUCCESS;
@@ -117,29 +120,45 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
             throw new Horde_ActiveSync_Exception_InvalidRequest('Missing required SEARCH_QUERY.');
         }
 
-        $search_query = array();
+        $search_query = [];
+
         switch (Horde_String::lower($search_name)) {
         case 'documentlibrary':
-        case 'mailbox':
+            $maxResults = 1000;
             if (!($search_query['query'] = $this->_parseQuery())) {
                 $search_status = self::SEARCH_STATUS_ERROR;
-                $store_status = self::STORE_STATUS_FOLDERSYNC;
+                $store_status = self::STORE_STATUS_PROTERR;
+            }
+        case 'mailbox':
+            $maxResults = 100;
+            if (!($search_query['query'] = $this->_parseQuery())) {
+                $search_status = self::SEARCH_STATUS_ERROR;
+                $store_status = self::STORE_STATUS_PROTERR;
             }
             break;
         case 'gal':
+            $maxResults = 100;
             $search_query['query'] = $this->_decoder->getElementContent();
+            break;
+        default:
+            $search_status = self::SEARCH_STATUS_ERROR;
+            $store_status = self::STORE_STATUS_PROTERR;
         }
 
         if (!$this->_decoder->getElementEndTag()) {
             return false;
         }
 
+        $range = null;
+
         $mime = Horde_ActiveSync::MIME_SUPPORT_NONE;
         if ($this->_decoder->getElementStartTag(self::SEARCH_OPTIONS)) {
-            $searchbodypreference = array();
+            $searchbodypreference = [];
             while(1) {
                 if ($this->_decoder->getElementStartTag(self::SEARCH_RANGE)) {
-                    $search_query['range'] = $this->_decoder->getElementContent();
+                    //FIXME: The result of including more than one Range element in a Search command request
+                    //       is undefined. The server MAY return a protocol status error in response to such a command request.
+                    $range = $this->_decoder->getElementContent();
                     if (!$this->_decoder->getElementEndTag()) {
                         return false;
                     }
@@ -198,7 +217,7 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
 
                 if ($this->_decoder->getElementStartTag(Horde_ActiveSync::AIRSYNCBASE_BODYPREFERENCE)) {
                     $this->_bodyPrefs($searchbodypreference);
-                    $searchbodypreference = empty($searchbodypreference['bodyprefs']) ? array() : $searchbodypreference['bodyprefs'];
+                    $searchbodypreference = empty($searchbodypreference['bodyprefs']) ? [] : $searchbodypreference['bodyprefs'];
                 }
 
                 if ($this->_decoder->getElementStartTag(Horde_ActiveSync::SYNC_MIMESUPPORT)) {
@@ -232,25 +251,52 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
             return false;
         }
 
-        $search_query['range'] = empty($search_query['range']) ? '0-99' : $search_query['range'];
-        switch(Horde_String::lower($search_name)) {
-        case 'mailbox':
-            $search_query['rebuildresults'] = !empty($search_query['rebuildresults']);
-            $search_query['deeptraversal'] =  !empty($search_query['deeptraversal']);
-            break;
+        if ($store_status === self::STORE_STATUS_SUCCESS) {
+            switch(Horde_String::lower($search_name)) {
+            case 'mailbox':
+                $search_query['rebuildresults'] = !empty($search_query['rebuildresults']);
+                $search_query['deeptraversal'] =  !empty($search_query['deeptraversal']);
+                break;
+            }
+
+            $start = 0;
+            $limit = $maxResults;
+            if ($range !== null && preg_match('/^(\d+)-(\d+)$/', $range, $matches)) {
+                $start = (int)$matches[1];
+                $end = (int)$matches[2];
+                if ($end < $start) {
+                    $store_status = self::STORE_STATUS_PROTERR;
+                } else {
+                    $limit = $end - $start + 1;
+                    if ($limit  > $maxResults) {
+                        // If the Range element value specified in the request exceeds the default range value,
+                        // a Status element (section 2.2.3.177.13) value of 12 is returned to indicate that the
+                        // maximum range has been exceeded
+                        $store_status = STORE_STATUS_RANGEERR;
+                    }
+                }
+            } else {
+                $store_status = self::STORE_STATUS_PROTERR;
+            }
         }
 
-        // Get search results from backend
-        if ($search_query['query']) {
-            $search_result = $this->_driver->getSearchResults($search_name, $search_query);
-            // @TODO: Remove for H6. Total should be returned from the search call,
-            // if it's not, do the best we can an use the count of results from
-            // this page.
-            if (empty($search_result['total'])) {
-                $search_result['total'] = count($search_result['rows']);
+        // In the Search command response, the Total element (section 2.2.3.184.3) indicates an estimate 
+        // of the total number of entries that matched the Query element (section 2.2.3.142.2) value.
+        if ($store_status === self::STORE_STATUS_SUCCESS && $search_query['query']) {
+            // Get search results from backend
+            $rows = $this->_driver->getSearchResults($search_name, $search_query);
+            if ($rows === null) {
+                $total = 0;
+                $store_status = self::STORE_STATUS_SERVERERR;
+            } else {
+                $total = count($rows);
+                if ($limit > 0) {
+                    $rows = array_slice($rows, $start, $limit);
+                }
             }
         } else {
-            $search_result = array();
+            $rows = null;
+            $total = 0;
         }
 
         /* Send output */
@@ -268,10 +314,8 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
         $this->_encoder->content($store_status);
         $this->_encoder->endTag();
 
-        if (is_array($search_result['rows']) && !empty($search_result['rows'])) {
-            $count = 0;
-            foreach ($search_result['rows'] as $u) {
-                $count++;
+        if ($rows) {
+            foreach ($rows as $u) {
                 switch (Horde_String::lower($search_name)) {
                 case 'documentlibrary':
                     $this->_encoder->startTag(self::SEARCH_RESULT);
@@ -372,22 +416,13 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
                 }
             }
 
-            if (!empty($search_query['range'])) {
-                $range = explode('-', $search_query['range']);
-                // If total results are less than max range,
-                // we have all results and must modify the returned range.
-                if ($count < ($range[1] - $range[0] + 1)) {
-                    $search_range = $range[0] . '-' . ($count - 1);
-                } else {
-                    $search_range = $search_query['range'];
-                }
-            }
+            $search_range = $start . '-' . ($start + count($rows) - 1);
             $this->_encoder->startTag(self::SEARCH_RANGE);
             $this->_encoder->content($search_range);
             $this->_encoder->endTag();
 
             $this->_encoder->startTag(self::SEARCH_TOTAL);
-            $this->_encoder->content($search_result['total']);
+            $this->_encoder->content($total);
             $this->_encoder->endTag();
         }
 

--- a/lib/Horde/ActiveSync/Wbxml/Decoder.php
+++ b/lib/Horde/ActiveSync/Wbxml/Decoder.php
@@ -85,9 +85,9 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
             $this->_buffer->add(chr($this->version));
             $this->_isWbxml = false;
             return;
-        } else {
-            $this->_isWbxml = true;
         }
+
+        $this->_isWbxml = true;
 
         $this->publicid = $this->_getMBUInt();
         if ($this->publicid == 0) {
@@ -123,7 +123,7 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     {
         // Ensure the buffer was created
         $this->_getTempStream();
-        // Need to read the stream into memeory since php://input isn't
+        // Need to read the stream into memory since php://input isn't
         // always seekable (Bug: 13160);
         $this->_buffer->add($this->_stream->getString());
         $this->_buffer->rewind();
@@ -139,30 +139,21 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     public function getElement()
     {
         $element = $this->getToken();
-        if (empty($element)) {
-            return false;
-        }
-        switch ($element[self::EN_TYPE]) {
-        case self::EN_TYPE_STARTTAG:
-            return $element;
-        case self::EN_TYPE_ENDTAG:
-            return $element;
-        case self::EN_TYPE_CONTENT:
+        if ($element !== false && $element[self::EN_TYPE] === self::EN_TYPE_CONTENT) {
             while (1) {
                 $next = $this->getToken();
-                if ($next == false) {
+                if ($next === false) {
                     return false;
-                } elseif ($next[self::EN_TYPE] == self::EN_CONTENT) {
-                    $element[self::EN_CONTENT] .= $next[self::EN_CONTENT];
-                } else {
+                }
+                if ($next[self::EN_TYPE] !== self::EN_CONTENT) {
                     $this->_ungetElement($next);
                     break;
                 }
+                $element[self::EN_CONTENT] .= $next[self::EN_CONTENT];
             }
-            return $element;
         }
 
-        return false;
+        return $element;
     }
 
     /**
@@ -220,14 +211,13 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     public function getElementStartTag($tag)
     {
         $element = $this->getToken();
+        if ($element !== false) {
+            if ($element[self::EN_TYPE] === self::EN_TYPE_STARTTAG &&
+                $element[self::EN_TAG] === $tag) {
+                $this->_lastStartElement = $element;
+                return $element;
+            }
 
-        if (!empty($element[self::EN_TYPE]) &&
-            $element[self::EN_TYPE] == self::EN_TYPE_STARTTAG &&
-            $element[self::EN_TAG] == $tag) {
-
-            $this->_lastStartElement = $element;
-            return $element;
-        } else {
             $this->_lastStartElement = false;
             $this->_ungetElement($element);
         }
@@ -243,9 +233,11 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     public function getElementEndTag()
     {
         $element = $this->getToken();
-        if ($element[self::EN_TYPE] == self::EN_TYPE_ENDTAG) {
-            return $element;
-        } else {
+        if ($element !== false) {
+            if ($element[self::EN_TYPE] == self::EN_TYPE_ENDTAG) {
+                return $element;
+            }
+
             $this->_logger->err('Unmatched end tag:');
             $this->_logger->err(print_r($element, true));
             $this->_ungetElement($element);
@@ -262,10 +254,12 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     public function getElementContent()
     {
         $element = $this->getToken();
-        if ($element[self::EN_TYPE] == self::EN_TYPE_CONTENT) {
-            return $element[self::EN_CONTENT];
+        if ($element !== false) {
+            if ($element[self::EN_TYPE] == self::EN_TYPE_CONTENT) {
+                return $element[self::EN_CONTENT];
+            }
+            $this->_ungetElement($element);
         }
-        $this->_ungetElement($element);
 
         return false;
     }
@@ -273,7 +267,7 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     /**
      * Get the next [start | content | end] tag.
      *
-     * @return array  The next, complete, token array.
+     * @return array|boolean  The next, complete, token array | false on failure.
      */
     public function getToken()
     {
@@ -286,7 +280,7 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
 
         $el = $this->_getToken();
 
-        if (!empty($el)) {
+        if ($el !== false) {
             $this->_logToken($el);
         }
 
@@ -332,12 +326,12 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
     /**
      * Get the next start tag, content or end tag
      *
-     * @return array  The element array.
+     * @return array|boolean  The element array or false on end of stream.
      */
    protected function _getToken() {
 
         // Get the data from the input stream
-        $element = array();
+        $element = [];
 
         while (1) {
             $byte = $this->_getByte();
@@ -436,6 +430,8 @@ class Horde_ActiveSync_Wbxml_Decoder extends Horde_ActiveSync_Wbxml
                 return $element;
             }
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Remove range usage and harden `SEARCH_AND` in `_doQuery()`
 - Remove erroneous $range parameter from recursive `SEARCH_AND` call and
eliminate (a non-working) per-mailbox range slicing, as range handling
belongs (and is already done) at the caller level. Add explicit validation
to `SEARCH_AND` unwrapping.

Remove reference return from `__get()` magic method in `Horde_ActiveSync_Message_Base`

Harden WBXML decoder against false/empty element checks (to be continued)
- Replace empty()/loose-equality checks with strict `!== false` comparisons
- Fix `getElement()` logic: return element directly for start/end tags,
  only loop for content concatenation; eliminates spurious `return false`
- Add missing `return false` at end of `_getToken()` (potential null return bug)
- Fix typo: "memeory" -> "memory" in comment
- Update `@return` docblocks to reflect `array|boolean` return types

Overhaul Search request handling with proper range validation and status codes
- Add `STORE_STATUS_RANGEERR` (12) constant per MS-ASCMD spec
- Add default case to search name switch; return `STORE_STATUS_PROTERR` for
  unknown store types
- Add per-type max results limits (mailbox/GAL: 100, documentlibrary: 1000)
- Move range parsing out of query map into dedicated `$range` variable;
  validate format and enforce max results ceiling, returning `RANGEERR` (12) if exceeded
  [this also fixes issue with caching done by `getSearchResults()`];
- Fix mailbox/documentlibrary error status: `PROTERR` instead of `FOLDERSYNC`
- Move pagination (array_slice) from driver into request handler; driver
  now returns full result set, caller owns slicing
- Replace `search_result['rows']/['total']` envelope with flat `$rows`/`$total`
- Simplify output loop: drop manual $count, derive search_range from
  `$start + count($rows)`
- Gate backend call behind `$store_status === SUCCESS` check

**IMPORTANT: This is required by and relies on changes in horde/Core#57.**
