### PR TITLE
More activesync fixes

### DIFF
--- a/lib/Horde/ActiveSync/Driver/Base.php
+++ b/lib/Horde/ActiveSync/Driver/Base.php
@@ -526,20 +526,13 @@ abstract class Horde_ActiveSync_Driver_Base
     abstract public function moveMessage($folderid, array $ids, $newfolderid);
 
     /**
-     * Returns array of items which contain contact information
+     * Returns search results for the given search parameters.
      *
-     * @param string $type   The search type; ['gal'|'mailbox']
-     * @param array $query   The search query. An array containing:
-     *  - query: (string) The search term.
-     *           DEFAULT: none, REQUIRED
-     *  - range: (string)   A range limiter.
-     *           DEFAULT: none (No range used).
+     * @param Horde_ActiveSync_Search_Params $params  The search parameters.
      *
-     * @return array  An array containing:
-     *  - rows:   An array of search results
-     *  - status: The search store status code.
+     * @return Horde_ActiveSync_Search_Results  The search results.
      */
-    abstract public function getSearchResults($type, array $query);
+    abstract public function getSearchResults(Horde_ActiveSync_Search_Params $params): Horde_ActiveSync_Search_Results;
 
     /**
      * Stat folder. Note that since the only thing that can ever change for a

--- a/lib/Horde/ActiveSync/Driver/Mock.php
+++ b/lib/Horde/ActiveSync/Driver/Mock.php
@@ -94,22 +94,15 @@ class Horde_ActiveSync_Driver_Mock extends Horde_ActiveSync_Driver_Base
     }
 
     /**
-     * Returns array of items which contain contact information
+     * Returns search results for the given search parameters.
      *
-     * @param string $type   The search type; ['gal'|'mailbox']
-     * @param array $query   The search query. An array containing:
-     *  - query: (string) The search term.
-     *           DEFAULT: none, REQUIRED
-     *  - range: (string)   A range limiter.
-     *           DEFAULT: none (No range used).
+     * @param Horde_ActiveSync_Search_Params $params  The search parameters.
      *
-     * @return array  An array containing:
-     *  - rows:   An array of search results
-     *  - status: The search store status code.
+     * @return Horde_ActiveSync_Search_Results  The search results.
      */
-    public function getSearchResults($type, array $query)
+    public function getSearchResults(Horde_ActiveSync_Search_Params $params): Horde_ActiveSync_Search_Results
     {
-        return array();
+        return [];
     }
 
     /**

--- a/lib/Horde/ActiveSync/Imap/Adapter.php
+++ b/lib/Horde/ActiveSync/Imap/Adapter.php
@@ -574,13 +574,15 @@ class Horde_ActiveSync_Imap_Adapter
     /**
      * Perform a search from a search mailbox request.
      *
-     * @param array $query  The query array.
+     * @param array $query          The search query.
+     * @param array $options        The search options.
+     * @param bool  $deepTraversal  Not currently supported.
      *
      * @return array  An array of 'uniqueid', 'searchfolderid' hashes.
      */
-    public function queryMailbox($query)
+    public function queryMailbox(array $query, array $options, bool $deepTraversal): array|int
     {
-        return $this->_doQuery($query['query']);
+        return $this->_doQuery($query, $options, $deepTraversal);
     }
 
     /**
@@ -897,21 +899,21 @@ class Horde_ActiveSync_Imap_Adapter
     /**
      * Perform an IMAP search based on a SEARCH request.
      *
-     * @param array $query  The search query.
+     * @param array $query          The search query.
+     * @param array $options        The search options (currently not used).
+     * @param bool  $deepTraversal  Not currently supported.
      *
-     * @return array  The results array containing an array of hashes:
+     * @todo Implement $deepTraversal support.
+     * @todo Implement $options support.
+     *
+     * @return array  Returns array containing an array of hashes:
      *   'uniqueid' => [The unique identifier of the result]
      *   'searchfolderid' => [The mailbox name that this result comes from]
      *
      * @throws Horde_ActiveSync_Exception
      */
-    protected function _doQuery(array $query)
+    protected function _doQuery(array $query, array $options, bool $deepTraversal): array|int
     {
-        $imap_query = new Horde_Imap_Client_Search_Query();
-        $imap_query->charset('UTF-8', false);
-        $mboxes = [];
-        $results = [];
-
         if ($query) {
             $q = $query[0];
             if (($q['op'] ?? '') === Horde_ActiveSync_Request_Search::SEARCH_AND) {
@@ -923,8 +925,11 @@ class Horde_ActiveSync_Imap_Adapter
             $query = [ $q['value'] ];
         }
 
+        $imap_query = new Horde_Imap_Client_Search_Query();
+        $imap_query->charset('UTF-8', false);
+
+        $mboxes = [];
         foreach ($query as $q) {
-            $op = $q['op'] ?? '';
             foreach ($q as $key => $value) {
                 switch ($key) {
                 case 'FolderType':
@@ -936,6 +941,7 @@ class Horde_ActiveSync_Imap_Adapter
                     $mboxes[] = new Horde_Imap_Client_Mailbox($value);
                     break;
                 case Horde_ActiveSync_Message_Mail::POOMMAIL_DATERECEIVED:
+                    $op = $q['op'] ?? '';
                     if ($op == Horde_ActiveSync_Request_Search::SEARCH_GREATERTHAN) {
                         $query_range = Horde_Imap_Client_Search_Query::DATE_SINCE;
                     } elseif ($op == Horde_ActiveSync_Request_Search::SEARCH_LESSTHAN) {
@@ -961,6 +967,7 @@ class Horde_ActiveSync_Imap_Adapter
             }
         }
 
+        $results = [];
         foreach ($mboxes as $mbox) {
             try {
                 $search_res = $this->_getImapOb()->search(
@@ -1012,9 +1019,9 @@ class Horde_ActiveSync_Imap_Adapter
      *              DEFAULT: false (Do not fetch header text).
      *   - structure: (boolean) Fetch message structure.
      *            DEFAULT: true (Fetch message structure).
-     *   - flags: (boolean) Fetch messagge flags.
+     *   - flags: (boolean) Fetch message flags.
      *            DEFAULT: true (Fetch message flags).
-     *   - envelope: (boolen) Fetch the envelope data.
+     *   - envelope: (boolean) Fetch the envelope data.
      *               DEFAULT: false (Do not fetch envelope). @since 2.4.0
      *
      * @return Horde_Imap_Fetch_Results  The results.

--- a/lib/Horde/ActiveSync/Request/Search.php
+++ b/lib/Horde/ActiveSync/Request/Search.php
@@ -120,27 +120,25 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
             throw new Horde_ActiveSync_Exception_InvalidRequest('Missing required SEARCH_QUERY.');
         }
 
-        $search_query = [];
+        $options = [];
+        $maxResults = 100;
 
         switch (Horde_String::lower($search_name)) {
         case 'documentlibrary':
             $maxResults = 1000;
-            if (!($search_query['query'] = $this->_parseQuery())) {
-                $search_status = self::SEARCH_STATUS_ERROR;
-                $store_status = self::STORE_STATUS_PROTERR;
-            }
+            // fall through
         case 'mailbox':
-            $maxResults = 100;
-            if (!($search_query['query'] = $this->_parseQuery())) {
+            $query = $this->_parseQuery();
+            if (!$query) {
                 $search_status = self::SEARCH_STATUS_ERROR;
                 $store_status = self::STORE_STATUS_PROTERR;
             }
             break;
         case 'gal':
-            $maxResults = 100;
-            $search_query['query'] = $this->_decoder->getElementContent();
+            $query = $this->_decoder->getElementContent();
             break;
         default:
+            $query = null;
             $search_status = self::SEARCH_STATUS_ERROR;
             $store_status = self::STORE_STATUS_PROTERR;
         }
@@ -150,10 +148,12 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
         }
 
         $range = null;
+        $rebuildResults = false;
+        $deepTraversal = false;
 
         $mime = Horde_ActiveSync::MIME_SUPPORT_NONE;
+        $searchbodypreference = [];
         if ($this->_decoder->getElementStartTag(self::SEARCH_OPTIONS)) {
-            $searchbodypreference = [];
             while(1) {
                 if ($this->_decoder->getElementStartTag(self::SEARCH_RANGE)) {
                     //FIXME: The result of including more than one Range element in a Search command request
@@ -164,51 +164,51 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
                     }
                 }
                 if ($this->_decoder->getElementStartTag(self::SEARCH_DEEPTRAVERSAL)) {
-                    if (!($search_query['deeptraversal'] = $this->_decoder->getElementContent())) {
-                        $search_query['deeptraversal'] = true;
+                    if (!($deepTraversal = $this->_decoder->getElementContent())) {
+                        $deepTraversal = true;
                     } elseif (!$this->_decoder->getElementEndTag()) {
                         return false;
                     }
                 }
                 if ($this->_decoder->getElementStartTag(self::SEARCH_REBUILDRESULTS)) {
-                    if (!($search_query['rebuildresults'] = $this->_decoder->getElementContent())) {
-                        $search_query['rebuildresults'] = true;
+                    if (!($rebuildResults = $this->_decoder->getElementContent())) {
+                        $rebuildResults = true;
                     } elseif (!$this->_decoder->getElementEndTag()) {
                         return false;
                     }
                 }
                 if ($this->_decoder->getElementStartTag(self::SEARCH_USERNAME)) {
-                    if (!($search_query['username'] = $this->_decoder->getElementContent())) {
+                    if (!($options['username'] = $this->_decoder->getElementContent())) {
                         return false;
                     } elseif (!$this->_decoder->getElementEndTag()) {
                         return false;
                     }
                 }
                 if ($this->_decoder->getElementStartTag(self::SEARCH_PASSWORD)) {
-                    if (!($search_query['password'] = $this->_decoder->getElementContent()))
+                    if (!($options['password'] = $this->_decoder->getElementContent()))
                         return false;
                     else
                         if(!$this->_decoder->getElementEndTag())
                         return false;
                 }
                 if ($this->_decoder->getElementStartTag(self::SEARCH_SCHEMA)) {
-                    if (!($search_query['schema'] = $this->_decoder->getElementContent())) {
-                        $search_query['schema'] = true;
+                    if (!($options['schema'] = $this->_decoder->getElementContent())) {
+                        $options['schema'] = true;
                     } elseif (!$this->_decoder->getElementEndTag()) {
                         return false;
                     }
                 }
                 // 14.1 Only
                 if ($this->_decoder->getElementStartTag(self::SEARCH_PICTURE)) {
-                    $search_query[self::SEARCH_PICTURE] = true;
+                    $options[self::SEARCH_PICTURE] = true;
                     if ($this->_decoder->getElementStartTag(self::SEARCH_MAXSIZE)) {
-                        $search_query[self::SEARCH_MAXSIZE] = $this->_decoder->getElementContent();
+                        $options[self::SEARCH_MAXSIZE] = $this->_decoder->getElementContent();
                         if (!$this->_decoder->getElementEndTag()) {
                             return false;
                         }
                     }
                     if ($this->_decoder->getElementStartTag(self::SEARCH_MAXPICTURES)) {
-                        $search_query[self::SEARCH_MAXPICTURES] = $this->_decoder->getElementContent();
+                        $options[self::SEARCH_MAXPICTURES] = $this->_decoder->getElementContent();
                         if (!$this->_decoder->getElementEndTag()) {
                             return false;
                         }
@@ -231,7 +231,7 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
                         $this->_rightsManagement($rm);
                     }
                     if ($this->_decoder->getElementStartTag(Horde_ActiveSync::AIRSYNCBASE_BODYPARTPREFERENCE)) {
-                        $this->_bodyPartPrefs($search_query);
+                        $this->_bodyPartPrefs($options);
                     }
                 }
 
@@ -252,51 +252,56 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
         }
 
         if ($store_status === self::STORE_STATUS_SUCCESS) {
-            switch(Horde_String::lower($search_name)) {
-            case 'mailbox':
-                $search_query['rebuildresults'] = !empty($search_query['rebuildresults']);
-                $search_query['deeptraversal'] =  !empty($search_query['deeptraversal']);
-                break;
-            }
+            $rebuildResults = !empty($rebuildResults);
+            $deepTraversal =  !empty($deepTraversal);
 
             $start = 0;
             $limit = $maxResults;
-            if ($range !== null && preg_match('/^(\d+)-(\d+)$/', $range, $matches)) {
-                $start = (int)$matches[1];
-                $end = (int)$matches[2];
-                if ($end < $start) {
-                    $store_status = self::STORE_STATUS_PROTERR;
-                } else {
-                    $limit = $end - $start + 1;
-                    if ($limit  > $maxResults) {
-                        // If the Range element value specified in the request exceeds the default range value,
-                        // a Status element (section 2.2.3.177.13) value of 12 is returned to indicate that the
-                        // maximum range has been exceeded
-                        $store_status = STORE_STATUS_RANGEERR;
+            if ($range !== null) {
+                if (preg_match('/^(\d+)-(\d+)$/', $range, $matches)) {
+                    $start = (int)$matches[1];
+                    $end = (int)$matches[2];
+                    if ($end < $start) {
+                        $store_status = self::STORE_STATUS_PROTERR;
+                    } else {
+                        $limit = $end - $start + 1;
+                        if ($limit  > $maxResults) {
+                            // If the Range element value specified in the request exceeds the default range value,
+                            // a Status element (section 2.2.3.177.13) value of 12 is returned to indicate that the
+                            // maximum range has been exceeded
+                            $store_status = self::STORE_STATUS_RANGEERR;
+                        }
                     }
+                } else {
+                    $store_status = self::STORE_STATUS_PROTERR;
                 }
-            } else {
-                $store_status = self::STORE_STATUS_PROTERR;
             }
         }
 
         // In the Search command response, the Total element (section 2.2.3.184.3) indicates an estimate 
         // of the total number of entries that matched the Query element (section 2.2.3.142.2) value.
-        if ($store_status === self::STORE_STATUS_SUCCESS && $search_query['query']) {
+        if ($store_status === self::STORE_STATUS_SUCCESS && $query) {
+            // Prepare search parameters
+            $params = new Horde_ActiveSync_Search_Params(
+                type: $search_name,
+                query: $query,
+                options: $options,
+                start: $start,
+                limit: $limit,
+                rebuildResults: $rebuildResults,
+                deepTraversal: $deepTraversal
+            );
+
             // Get search results from backend
-            $rows = $this->_driver->getSearchResults($search_name, $search_query);
-            if ($rows === null) {
-                $total = 0;
+            $results = $this->_driver->getSearchResults($params);
+
+            /* not yet */
+            // $store_status = $results->status;
+            if ($results->rows === null) {
                 $store_status = self::STORE_STATUS_SERVERERR;
-            } else {
-                $total = count($rows);
-                if ($limit > 0) {
-                    $rows = array_slice($rows, $start, $limit);
-                }
             }
         } else {
-            $rows = null;
-            $total = 0;
+            $results = null;
         }
 
         /* Send output */
@@ -314,8 +319,8 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
         $this->_encoder->content($store_status);
         $this->_encoder->endTag();
 
-        if ($rows) {
-            foreach ($rows as $u) {
+        if ($results && $results->rows) {
+            foreach ($results->rows as $u) {
                 switch (Horde_String::lower($search_name)) {
                 case 'documentlibrary':
                     $this->_encoder->startTag(self::SEARCH_RESULT);
@@ -416,13 +421,13 @@ class Horde_ActiveSync_Request_Search extends Horde_ActiveSync_Request_SyncBase
                 }
             }
 
-            $search_range = $start . '-' . ($start + count($rows) - 1);
+            $search_range = $start . '-' . ($start + count($results->rows) - 1);
             $this->_encoder->startTag(self::SEARCH_RANGE);
             $this->_encoder->content($search_range);
             $this->_encoder->endTag();
 
             $this->_encoder->startTag(self::SEARCH_TOTAL);
-            $this->_encoder->content($total);
+            $this->_encoder->content($results->total);
             $this->_encoder->endTag();
         }
 


### PR DESCRIPTION
Redesign `_handle()` to use `Search_Params`/`Search_Results` objects

- Introduce `Horde_ActiveSync_Search_Params` to pass typed search parameters
  to `getSearchResults()` instead of a loosely-structured `$search_query` array
- Separate `$query`, `$options`, `$rebuildResults`, and `$deepTraversal` into
  distinct variables for clarity
- Fix missing break in `documentlibrary` case causing fall-through into
  mailbox and overwriting `$maxResults` with 100
- Fix `$maxResults`, `$query`, `$searchbodypreference` undefined when Options
  block is absent or default switch branch is hit
- Fix null Range being treated as a protocol error; omitting Range is
  valid and should use default start/limit values
- Fix bare `STORE_STATUS_RANGEERR` reference (missing `self::`)
- Results pagination and total count now delegated to the backend via
  `Search_Results` object instead of being done in-place with `array_slice()`

Update `queryMailbox()` and `_doQuery()` to accept options and `deepTraversal` in `Adapter.php`

- Add `$options` and `$deepTraversal` parameters to `queryMailbox()` and `_doQuery()`,
  matching the `Search_Params` refactor in the driver layer
- Add typed signatures (array, bool, return type) to both methods
- Move `$imap_query`, `$mboxes`, and `$results` initialization to after the
  early AND-query validation, avoiding unnecessary object creation on error

**IMPORTANT: Requires changes in horde/core#61.**
