### PR TITLE
fix: add missing explicit property declarations to avoid deprecated dynamic property errors

### DIFF
--- a/lib/Horde/ActiveSync.php
+++ b/lib/Horde/ActiveSync.php
@@ -20,7 +20,7 @@
  * @property-read Horde_ActiveSync_Wbxml_Encoder $encoder The Wbxml encoder.
  * @property-read Horde_ActiveSync_Wbxml_Decoder $decoder The Wbxml decoder.
  * @property-read Horde_ActiveSync_State_Base $state      The state object.
- * @property-read Horde_Controller_Reqeust_Http $request  The HTTP request object.
+ * @property-read Horde_Controller_Request_Http $request  The HTTP request object.
  * @property-read Horde_ActiveSync_Driver_Base $driver    The backend driver object.
  * @property-read boolean|string $provisioning Provisioning support: True, False, or 'loose'
  * @property-read boolean $multipart Indicate this is a multipart request.
@@ -381,10 +381,38 @@ class Horde_ActiveSync
     protected $_certPath;
 
     /**
+     * The policy key.
+     *
+     * @var integer
+     */
+    protected $_policykey;
+
+    /**
      *
      * @var Horde_ActiveSync_Device
      */
     protected static $_device;
+
+    /**
+     * The HTTP request object.
+     *
+     * @var Horde_Controller_Request_Http
+     */
+    protected $_request;
+
+    /**
+     * The backend driver.
+     *
+     * @var Horde_ActiveSync_Driver_Base
+     */
+    protected $_driver;
+
+    /**
+     * Device state manager.
+     *
+     * @var Horde_ActiveSync_State_Base
+     */
+    protected $_state;
 
     /**
      * Wbxml encoder

--- a/lib/Horde/ActiveSync/Collections.php
+++ b/lib/Horde/ActiveSync/Collections.php
@@ -1412,7 +1412,7 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
     /**
      * Iterator
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_collections);
     }

--- a/lib/Horde/ActiveSync/Search/Params.php
+++ b/lib/Horde/ActiveSync/Search/Params.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Horde_ActiveSync_Search_Params
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Dmitry Petrov <dpetrov67@gmail.com>
+ * @package   ActiveSync
+ */
+
+/**
+ * Horde_ActiveSync_Search_Params class for Horde_ActiveSync.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Dmitry Petrov <dpetrov67@gmail.com>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Search_Params
+{
+    /**
+     * Constructor.
+     *
+     * @param string $type            The search type; one of 'gal', 'mailbox',
+     *                                or 'documentlibrary'.
+     * @param array  $query           The search query.
+     * @param array  $options         The search options.
+     * @param int    $start           The start offset for results.
+     * @param int    $limit           The maximum number of results to return.
+     * @param bool   $rebuildResults  If true, invalidate any cached search;
+     *                                otherwise use cached results if available.
+     * @param bool   $deepTraversal   If true, traverse sub-folders.
+     */
+    public function __construct(
+        public string $type,
+        public array $query,
+        public array $options,
+        public int $start,
+        public int $limit,
+        public bool $rebuildResults,
+        public bool $deepTraversal,
+    ) {
+    }
+}

--- a/lib/Horde/ActiveSync/Search/Results.php
+++ b/lib/Horde/ActiveSync/Search/Results.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Horde_ActiveSync_Search_Results
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Dmitry Petrov <dpetrov67@gmail.com>
+ * @package   ActiveSync
+ */
+
+/**
+ * Horde_ActiveSync_Search_Results class for Horde_ActiveSync.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Dmitry Petrov <dpetrov67@gmail.com>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Search_Results
+{
+    /**
+     * Constructor.
+     *
+     * @param int        $total   The total number of results available.
+     * @param array|null $rows    The result rows, or null if error.
+     * @param int        $status  The search status code.
+     */
+    public function __construct(
+        public int    $total,
+        public ?array $rows,
+        public int    $status,
+    ) {
+    }
+}


### PR DESCRIPTION
Add missing explicit property declarations to avoid deprecated dynamic property errors:

- Declare $_request, $_driver, $_state, $_policykey
- Fix typo: Horde_Controller_Reqeust_Http -> Horde_Controller_Request_Http

This is a simple fix, but maybe we should also refactor a little bit?

It looks like this class is not extended, and only used in one place. Maybe it makes sense to:

 -  use constructor property promotion,
 -  drop _ from variable names and add explicit types where is it absolutely clear.

Or we can do it later.