### PR TITLE
fix(activesync): Missing collection class in error handler

### DIFF
--- a/lib/Horde/ActiveSync/Request/Sync.php
+++ b/lib/Horde/ActiveSync/Request/Sync.php
@@ -1242,6 +1242,11 @@ class Horde_ActiveSync_Request_Sync extends Horde_ActiveSync_Request_SyncBase
      * Helper for handling sync errors
      *
      * @param array $collection
+     *
+     * @see MS-ASCMD 2.2.2.18 Sync command response structure
+     * @see MS-ASCMD 2.2.3.29.4 Class element in EAS > 12.1 sent via OPTIONS
+     * @see Line 706-711 for class retrieval pattern
+     * @see Collections.php:1063-1065 for FolderGone exception pattern
      */
     protected function _handleError(array $collection)
     {
@@ -1259,6 +1264,29 @@ class Horde_ActiveSync_Request_Sync extends Horde_ActiveSync_Request_SyncBase
             $collection['newsynckey'] = Horde_ActiveSync_State_Base::getNewSyncKey(($this->_statusCode == self::STATUS_KEYMISM) ? 0 : $collection['synckey']);
             if ($collection['synckey'] != '0') {
                 $this->_state->removeState(array('synckey' => $collection['synckey']));
+            }
+        }
+
+        // Collection class may be missing in EAS > 12.1; retrieve from cache or signal folder resync
+        if (empty($collection['class'])) {
+            $collection['class'] = $this->_collections->getCollectionClass($collection['id']);
+            if (!$collection['class']) {
+                // Cannot determine class - collection may be deleted/invalid, signal FOLDERSYNC required
+                if (isset($this->_logger)) {
+                    $this->_logger->err(sprintf(
+                        'Cannot determine collection class for id=%s - collection may be deleted or cache invalid',
+                        $collection['id']
+                    ));
+                }
+                $this->_statusCode = self::STATUS_FOLDERSYNC_REQUIRED;
+                // Use fallback class value to prevent encoder crash while sending FOLDERSYNC_REQUIRED status
+                $collection['class'] = 'Email';
+            } elseif (isset($this->_logger)) {
+                $this->_logger->debug(sprintf(
+                    'Retrieved missing collection class from cache: %s for id=%s',
+                    $collection['class'],
+                    $collection['id']
+                ));
             }
         }
 


### PR DESCRIPTION
Retrieve missing collection class from cache or signal FOLDERSYNC_REQUIRED.

Since EAS 12.1 collection class is not sent at folder level but via
OPTIONS or ADD commands (see line 624-627). The error handler must
handle a missing class field properly.

See: MS-ASCMD 2.2.3.29.4 Class element in EAS > 12.1
