### PR TITLE
Refactor sync state saving logic

### DIFF
--- a/lib/Horde/ActiveSync/State/Sql.php
+++ b/lib/Horde/ActiveSync/State/Sql.php
@@ -417,31 +417,95 @@ class Horde_ActiveSync_State_Sql extends Horde_ActiveSync_State_Base
                     time()])
             )
         );
-        try {
-            $this->_db->insertBlob($this->_syncStateTable, $params, 'sync_key', $params['sync_key']);
-        } catch (Horde_Db_Exception $e) {
-            // Might exist already if the last sync attempt failed.
-            $this->_logger->notice(
-                sprintf(
-                    'STATE: Error saving state, checking if this is due to previous synckey %s not being accepted by client.',
-                    $this->_syncKey
-                )
-            );
+        $this->_saveSyncStateRow($params);
+    }
+
+    /**
+     * Persist sync state using Horde_Db (update, else insert).
+     *
+     * Avoids DELETE+INSERT and database-specific UPSERT syntax. Concurrent
+     * PING/SYNC requests for the same sync_key may race; a failed insert is
+     * retried as an update when the row already exists.
+     *
+     * @param array $params  Column data for horde_activesync_state.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    protected function _saveSyncStateRow(array $params)
+    {
+        $where = ['sync_key = ?', [$params['sync_key']]];
+        $started = false;
+
+        if (!$this->_db->transactionStarted()) {
+            $this->_db->beginDbTransaction();
+            $started = true;
         }
 
         try {
-            $this->_db->delete('DELETE FROM ' . $this->_syncStateTable . ' WHERE sync_key = ?', [$this->_syncKey]);
-            $this->_db->insertBlob($this->_syncStateTable, $params, 'sync_key', $params['sync_key']);
+            if ($this->_db->updateBlob($this->_syncStateTable, $params, $where)) {
+                if ($started) {
+                    $this->_db->commitDbTransaction();
+                }
+                return;
+            }
+
+            try {
+                $this->_db->insertBlob(
+                    $this->_syncStateTable,
+                    $params,
+                    'sync_key',
+                    $params['sync_key']
+                );
+            } catch (Horde_Db_Exception $e) {
+                if (!$this->_syncStateExists($params['sync_key'])) {
+                    throw $e;
+                }
+
+                Horde::log(
+                    'STATE: Concurrent insert for synckey '
+                    . $params['sync_key']
+                    . '; updating existing row.',
+                    'DEBUG'
+                );
+
+                if (!$this->_db->updateBlob($this->_syncStateTable, $params, $where)) {
+                    throw $e;
+                }
+            }
+
+            if ($started) {
+                $this->_db->commitDbTransaction();
+            }
         } catch (Horde_Db_Exception $e) {
-            $this->_logger->err(
-                sprintf(
-                    'STATE: Unrecoverable error while saving state for synckey %s: %s',
-                    $this->_syncKey,
-                    $e->getMessage()
-                )
-            );
+            if ($started) {
+                try {
+                    $this->_db->rollbackDbTransaction();
+                } catch (Horde_Db_Exception $e2) {
+                }
+            }
+
+            Horde::log($e, 'ERR');
             throw new Horde_ActiveSync_Exception($e);
         }
+    }
+
+    /**
+     * Check if a sync state row exists for the given sync key.
+     *
+     * @param string $syncKey  The sync key.
+     *
+     * @return boolean
+     * @throws Horde_Db_Exception
+     */
+    protected function _syncStateExists($syncKey)
+    {
+        return (bool) $this->_db->selectValue(
+            sprintf(
+                'SELECT 1 FROM %s WHERE sync_key = ?',
+                $this->_db->quoteTableName($this->_syncStateTable)
+            ),
+            [$syncKey]
+        );
     }
 
     /**

--- a/lib/Horde/ActiveSync/State/Sql.php
+++ b/lib/Horde/ActiveSync/State/Sql.php
@@ -461,6 +461,7 @@ class Horde_ActiveSync_State_Sql extends Horde_ActiveSync_State_Base
                     throw $e;
                 }
 
+                // TODO: Switch to DI PSR-3 Logger
                 Horde::log(
                     'STATE: Concurrent insert for synckey '
                     . $params['sync_key']


### PR DESCRIPTION
# Fix ActiveSync state persistence race

## Summary

Replaces the fragile `INSERT` → `DELETE` → `INSERT` pattern in `Horde_ActiveSync_State_Sql::save()` with a database-agnostic update-or-insert flow using Horde_Db (`updateBlob` / `insertBlob` and transactions).

This addresses recurring `Unique violation` errors on `horde_activesync_state_pkey` when PING and SYNC requests run concurrently for the same device and `sync_key`, which could leave sync state inconsistent and surface as `STATE: Error saving state` in ActiveSync logs.

## Problem

Under load (typical scenario: long-running PING handler polling collections while a SYNC request updates the same collection’s `sync_key`), two PHP workers could:

1. Both attempt `INSERT` with the same `sync_key`
2. One fails with a primary-key violation (logged in `horde.log`)
3. Both run `DELETE` + `INSERT`, racing again on the same key

Observed symptoms during Nag + ActiveSync 16.0 testing:

- `SQLSTATE[23505]: Unique violation … horde_activesync_state_pkey` in `/tmp-horde/horde.log`
- `STATE: Error saving state, checking if this is due to previous synckey …` in device ActiveSync logs
- Occasional sync instability despite successful task-level operations

## Solution

- New protected method `_saveSyncStateRow()`:
  - `UPDATE` via `Horde_Db_Adapter::updateBlob()` when the row exists
  - `INSERT` via `insertBlob()` only when no row was updated
  - On insert failure, verify the row exists (`_syncStateExists()`); if another request won the race, retry `updateBlob()` instead of failing
- Wrap in `beginDbTransaction()` / `commitDbTransaction()` when not already inside a transaction (same pattern as `Horde_SessionHandler_Storage_Sql`)
- **No** database-specific UPSERT (`ON CONFLICT`, `REPLACE`, etc.) — works across all backends supported by Horde_Db
- **No** `DELETE` between write attempts

Logging for the new paths uses `Horde::log()` (errors and concurrent-insert debug), not `sprintf`-formatted ActiveSync logger messages.

## Changed files

| File | Change |
|------|--------|
| `lib/Horde/ActiveSync/State/Sql.php` | `save()` delegates to `_saveSyncStateRow()`; add `_saveSyncStateRow()`, `_syncStateExists()` |

## Test plan

- [ ] Trigger ActiveSync SYNC (e.g. create/edit/delete a task on iOS) while the device maintains an open PING connection
- [ ] Confirm `/tmp-horde/horde.log` no longer shows `Unique violation` on `horde_activesync_state` for the test device
- [ ] Confirm device ActiveSync log no longer shows `STATE: Error saving state, checking if this is due to previous synckey`
- [ ] Re-run existing Nag ActiveSync test cases for task CRUD (regression: item-level sync unchanged)
- [ ] Smoke-test on the deployment DB backend (e.g. PostgreSQL); optional: repeat on MySQL/SQLite if available

## Notes

- Part of stabilizing ActiveSync 16.0 + Nag; does not address list/folder sync or task migration (separate work packages P2–P4).
- If this patch lives in a vendor tree, consider upstreaming to `horde/ActiveSync` or pinning via Composer patch so `composer update` does not drop the change.
