### PR TITLE
Fix/handling hierarchy

### DIFF
--- a/lib/Horde/ActiveSync/Collections.php
+++ b/lib/Horde/ActiveSync/Collections.php
@@ -1171,7 +1171,8 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
             return self::COLLECTION_ERR_SERVER;
         }
 
-        if (!$this->haveHierarchy()) {
+        if ($this->_as->device->version >= Horde_ActiveSync::VERSION_TWELVEONE
+            && !$this->haveHierarchy()) {
             $this->_logger->info(
                 'COLLECTIONS: Hierarchy sync required, terminating pollForChanges.'
             );

--- a/lib/Horde/ActiveSync/Collections.php
+++ b/lib/Horde/ActiveSync/Collections.php
@@ -1226,9 +1226,22 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
                 try {
                     $this->initCollectionState($collection, true);
                 } catch (Horde_ActiveSync_Exception_StateGone $e) {
+                    if (!empty($options['pingable'])) {
+                        $this->_logger->notice(
+                            sprintf(
+                                'COLLECTIONS: State not found for %s during PING; dropping orphan collection from cache.',
+                                $id
+                            )
+                        );
+                        $this->_cache->removePingableCollection($id);
+                        $this->_cache->removeCollection($id, true);
+                        unset($this->_collections[$id]);
+                        $this->save();
+                        continue;
+                    }
                     $this->_logger->notice(
                         sprintf(
-                            'COLLECTIONS: State not found for %s. Continuing by rquesting a SYNC.',
+                            'COLLECTIONS: State not found for %s. Continuing by requesting a SYNC.',
                             $id
                         )
                     );

--- a/lib/Horde/ActiveSync/Collections.php
+++ b/lib/Horde/ActiveSync/Collections.php
@@ -1171,6 +1171,13 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
             return self::COLLECTION_ERR_SERVER;
         }
 
+        if (!$this->haveHierarchy()) {
+            $this->_logger->info(
+                'COLLECTIONS: Hierarchy sync required, terminating pollForChanges.'
+            );
+            return self::COLLECTION_ERR_FOLDERSYNC_REQUIRED;
+        }
+
         // Need to update AND SAVE the timestamp for race conditions to be
         // detected.
         $this->lasthbsyncstarted = $started;

--- a/lib/Horde/ActiveSync/Collections.php
+++ b/lib/Horde/ActiveSync/Collections.php
@@ -666,7 +666,8 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
      */
     public function haveHierarchy()
     {
-        return isset($this->_cache->hierarchy);
+        return !empty($this->_cache->hierarchy)
+            && $this->_cache->hierarchy !== '0';
     }
 
     /**
@@ -1163,12 +1164,25 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
             )
         );
 
-        // If pinging, make sure we have pingable collections. Note we can't
-        // filter on them here because the collections might change during the
-        // loop below.
-        if (!empty($options['pingable']) && !$this->havePingableCollections()) {
-            $this->_logger->err('COLLECTIONS: No pingable collections.');
-            return self::COLLECTION_ERR_SERVER;
+        if (!empty($options['pingable'])) {
+            if ($this->collectionsNeedFolderResync()) {
+                return self::COLLECTION_ERR_FOLDERSYNC_REQUIRED;
+            }
+
+            $this->restorePingableCollectionsFromCache();
+
+            // If pinging, make sure we have pingable collections. Note we can't
+            // filter on them here because the collections might change during the
+            // loop below.
+            if (!$this->havePingableCollections()) {
+                $this->_logger->err('COLLECTIONS: No pingable collections.');
+                if ($this->_as->device->version >= Horde_ActiveSync::VERSION_TWELVEONE
+                    && !$this->haveHierarchy()) {
+                    return self::COLLECTION_ERR_FOLDERSYNC_REQUIRED;
+                }
+
+                return self::COLLECTION_ERR_SERVER;
+            }
         }
 
         if ($this->_as->device->version >= Horde_ActiveSync::VERSION_TWELVEONE
@@ -1408,12 +1422,108 @@ class Horde_ActiveSync_Collections implements IteratorAggregate
     }
 
     /**
+     * True if a collection has item sync state but no folder cache entry.
+     *
+     * The client must run FolderSync to remap folder ids (common after a
+     * partial cache reset or hierarchy invalidation).
+     *
+     * @return boolean
+     */
+    public function collectionsNeedFolderResync()
+    {
+        foreach ($this->_cache->getCollections(false) as $id => $collection) {
+            $synckey = $collection['synckey'] ?? '';
+            if ($synckey === '' && !empty($collection['lastsynckey'])) {
+                $synckey = $collection['lastsynckey'];
+            }
+            if ($synckey === '' || $synckey === '0') {
+                continue;
+            }
+            if (!$this->_cache->getFolder($id)) {
+                $this->_logger->info(
+                    sprintf(
+                        'COLLECTIONS: Collection %s has sync state but no folder cache entry; FolderSync required.',
+                        $id
+                    )
+                );
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Re-mark collections that have synckeys as PINGable.
+     *
+     * Outlook and similar clients may send explicit PING folder lists before
+     * synckeys exist; a previous request must not leave the device with no
+     * pingable collections until the user resets the account.
+     *
+     * @return boolean  True if the sync cache was updated.
+     */
+    public function restorePingableCollectionsFromCache()
+    {
+        $updated = false;
+
+        foreach ($this->_cache->getCollections(false) as $id => $collection) {
+            $synckey = $collection['synckey'] ?? '';
+            if ($synckey === '' && !empty($collection['lastsynckey'])) {
+                $synckey = $collection['lastsynckey'];
+            }
+            if ($synckey === '' || $synckey === '0' || !$this->_cache->getFolder($id)) {
+                continue;
+            }
+
+            if (!$this->_cache->collectionIsPingable($id)) {
+                $this->_cache->setPingableCollection($id);
+                $updated = true;
+            }
+
+            if (!isset($this->_collections[$id])) {
+                if (empty($collection['class'])) {
+                    try {
+                        $collection['class'] = $this->getCollectionClass($id);
+                    } catch (Horde_ActiveSync_Exception $e) {
+                        continue;
+                    }
+                }
+                if (empty($collection['serverid'])) {
+                    try {
+                        $collection['serverid'] = $this->getBackendIdForFolderUid($id);
+                    } catch (Horde_ActiveSync_Exception $e) {
+                        continue;
+                    }
+                }
+                if (empty($collection['synckey']) && !empty($collection['lastsynckey'])) {
+                    $collection['synckey'] = $collection['lastsynckey'];
+                }
+                $this->_collections[$id] = $collection;
+            }
+        }
+
+        if ($updated) {
+            $this->save();
+        }
+
+        return $updated;
+    }
+
+    /**
      * Marks all loaded collections with a synckey as pingable.
      */
     public function updatePingableFlag()
     {
+        if (!count($this->_collections)) {
+            return;
+        }
+
         $collections = $this->_cache->getCollections(false);
         foreach ($collections as $id => $collection) {
+            if (!isset($this->_collections[$id])) {
+                continue;
+            }
             if (!empty($this->_collections[$id]['synckey'])) {
                 $this->_logger->meta(
                     sprintf(

--- a/lib/Horde/ActiveSync/Request/Ping.php
+++ b/lib/Horde/ActiveSync/Request/Ping.php
@@ -143,10 +143,22 @@ class Horde_ActiveSync_Request_Ping extends Horde_ActiveSync_Request_Base
             $this->_logger->info('Handling empty PING request.');
             $isEmpty = true;
             $collections->loadCollectionsFromCache();
+            $collections->restorePingableCollectionsFromCache();
             if ($collections->collectionCount() == 0
                 || !$collections->havePingableCollections()) {
-                $this->_logger->warn('Empty PING request with no cached collections. Request full PING.');
-                $this->_statusCode = self::STATUS_MISSING;
+                if ($collections->collectionsNeedFolderResync()
+                    || ($this->_device->version >= Horde_ActiveSync::VERSION_TWELVEONE
+                        && !$collections->haveHierarchy())) {
+                    $this->_logger->info(
+                        'Empty PING with stale folder or hierarchy state; requesting FolderSync.'
+                    );
+                    $this->_statusCode = self::STATUS_FOLDERSYNCREQD;
+                } else {
+                    $this->_logger->warn(
+                        'Empty PING request with no cached collections. Request full PING.'
+                    );
+                    $this->_statusCode = self::STATUS_MISSING;
+                }
                 $this->_handleGlobalError();
                 return true;
             }
@@ -162,6 +174,7 @@ class Horde_ActiveSync_Request_Ping extends Horde_ActiveSync_Request_Base
             }
             $this->_logger->meta(sprintf('Actual heartbeat value in use is %s.', $heartbeat));
             if ($this->_decoder->getElementStartTag(self::FOLDERS)) {
+                $pingCollectionsLoaded = false;
                 while ($this->_decoder->getElementStartTag(self::FOLDER)) {
                     $collection = [];
                     if ($this->_decoder->getElementStartTag(self::SERVERENTRYID)) {
@@ -181,14 +194,43 @@ class Horde_ActiveSync_Request_Ping extends Horde_ActiveSync_Request_Base
                         // iOS clients that request collections in PING before
                         // they issue an initial SYNC for them.
                         $collections->addCollection($collection, true);
+                        $pingCollectionsLoaded = true;
                     } catch (Horde_ActiveSync_Exception_StateGone $e) {
                     }
                 }
 
                 // Since PING sends all or none (no PARTIAL) we update the
                 // pingable flags so we have it for an empty PING.
-                $collections->validateFromCache();
-                $collections->updatePingableFlag();
+                if ($pingCollectionsLoaded) {
+                    $collections->validateFromCache();
+                    $collections->updatePingableFlag();
+                } else {
+                    // Outlook and others may list folders in PING before a
+                    // synckey exists; do not clear pingable flags on cached
+                    // collections. Fall back to the last known PING set.
+                    $this->_logger->info(
+                        'No collections loaded from explicit PING folder list; using cached collections.'
+                    );
+                    $collections->loadCollectionsFromCache();
+                    $collections->restorePingableCollectionsFromCache();
+                    if ($collections->collectionCount() == 0) {
+                        if ($collections->collectionsNeedFolderResync()
+                            || ($this->_device->version >= Horde_ActiveSync::VERSION_TWELVEONE
+                                && !$collections->haveHierarchy())) {
+                            $this->_logger->info(
+                                'Explicit PING with stale folder or hierarchy state; requesting FolderSync.'
+                            );
+                            $this->_statusCode = self::STATUS_FOLDERSYNCREQD;
+                        } else {
+                            $this->_logger->warn(
+                                'Explicit PING request with no loadable collections.'
+                            );
+                            $this->_statusCode = self::STATUS_MISSING;
+                        }
+                        $this->_handleGlobalError();
+                        return true;
+                    }
+                }
 
                 if (!$this->_decoder->getElementEndTag()) {
                     throw new Horde_ActiveSync_Exception('Protocol Error');
@@ -246,12 +288,14 @@ class Horde_ActiveSync_Request_Ping extends Horde_ActiveSync_Request_Base
                         if ($this->_device->version < Horde_ActiveSync::VERSION_FOURTEEN) {
                             $this->_logger->warn('Version is < 14.0, returning false since we have no PINGABLE collections.');
                             return false;
-                        } else {
-                            $this->_logger->warn('Version is >= 14.0 returning status code 132 since we have no PINGABLE collections.');
-                            $this->_statusCode = Horde_ActiveSync_Status::STATEFILE_NOT_FOUND;
-                            $this->_handleGlobalError();
-                            return true;
                         }
+
+                        $this->_logger->warn(
+                            'No PINGABLE collections; requesting FolderSync instead of status 132.'
+                        );
+                        $this->_statusCode = self::STATUS_FOLDERSYNCREQD;
+                        $this->_handleGlobalError();
+                        return true;
                 }
             } elseif ($changes) {
                 $collections->save(true);

--- a/lib/Horde/ActiveSync/Request/Ping.php
+++ b/lib/Horde/ActiveSync/Request/Ping.php
@@ -210,6 +210,16 @@ class Horde_ActiveSync_Request_Ping extends Horde_ActiveSync_Request_Base
 
         // Start waiting for changes, but only if we don't have any errors
         if ($this->_statusCode == self::STATUS_NOCHANGES) {
+            if ($this->_device->version >= Horde_ActiveSync::VERSION_TWELVEONE
+                && !$collections->haveHierarchy()) {
+                $this->_logger->info(
+                    'No HIERARCHY SYNCKEY in sync_cache during PING, requesting FolderSync.'
+                );
+                $this->_statusCode = self::STATUS_FOLDERSYNCREQD;
+                $this->_handleGlobalError();
+                return true;
+            }
+
             $changes = $collections->pollForChanges($heartbeat, $interval, ['pingable' => true]);
             if ($changes !== true && $changes !== false) {
                 switch ($changes) {


### PR DESCRIPTION
# Request FolderSync when hierarchy is invalid during PING

## Summary

When the server invalidates the folder hierarchy synckey in the device sync cache (for example after task list or calendar folder changes in a groupware app), clients were only forced to run **FolderSync** on the next **SYNC** request. **PING** could continue for minutes without telling the device to refresh its folder hierarchy, so new or removed folders did not appear until the user triggered an unrelated sync (e.g. editing a task).

This change aligns **PING** with the existing **SYNC** behaviour (ActiveSync 12.1+): if `haveHierarchy()` is false, return **FolderSync required** instead of waiting in `pollForChanges()`.

## Changes

### `lib/Horde/ActiveSync/Request/Ping.php`

Before entering the PING wait loop, if the device protocol version is **≥ 12.1** and the sync cache has no valid hierarchy synckey (`!haveHierarchy()`), respond immediately with PING status **7** (`STATUS_FOLDERSYNCREQD`) and stop processing.

This mirrors the check already present at the start of `Horde_ActiveSync_Request_Sync` for `STATUS_FOLDERSYNC_REQUIRED` (12).

### `lib/Horde/ActiveSync/Collections.php`

At the beginning of `pollForChanges()`, if the device is **≥ 12.1** and `haveHierarchy()` is false, return `COLLECTION_ERR_FOLDERSYNC_REQUIRED` so any PING path that reaches the poll loop also terminates with FolderSync required (same outcome as the explicit handling in `Ping.php`).

## Why version ≥ 12.1

The hierarchy synckey in `Horde_ActiveSync_SyncCache` and the associated status codes are part of the ActiveSync **12.1** folder hierarchy model. Older clients use a different folder sync flow; Horde already gates the SYNC-side check on `VERSION_TWELVEONE` (`'12.1'`). Both **Ping.php** and **Collections.php** use the same guard so clients **≤ 12.0** are unchanged.

## Behaviour notes

- Invalidating hierarchy means setting the cache `hierarchy` value to empty/`'0'` (see `SyncCache::__isset` / `haveHierarchy()`), not clearing the folder cache.
- PING status **7** and `COLLECTION_ERR_FOLDERSYNC_REQUIRED` were already handled in `Ping.php`; this change ensures the condition is detected **before** a long heartbeat wait.
- A cache timestamp bump alone (`COLLECTION_ERR_STALE`) only ends PING early; it does not instruct the client to run FolderSync.

## Test plan

- [ ] Device on ActiveSync **12.1+** (e.g. iOS Mail/Tasks): invalidate hierarchy on server (demux task lists or similar), confirm next **PING** returns FolderSync required (status 7) in server log.
- [ ] Confirm **FolderSync** runs and delivers `FolderHierarchy:Add` / `Remove` as appropriate.
- [ ] Confirm normal PING/SYNC still works when hierarchy synckey is valid.
- [ ] No change expected for clients **&lt; 12.1** (guard not applied).

## Related work

Companion changes in **Nag** (separate PR): web-side task list create/delete updates `sync_lists` and invalidates hierarchy without pruning device folder cache before FolderSync.
