### PR TITLE
Fix/modern i os notes multiplexing

### DIFF
--- a/lib/Horde/ActiveSync/Device.php
+++ b/lib/Horde/ActiveSync/Device.php
@@ -161,6 +161,11 @@ class Horde_ActiveSync_Device
                     $this->_sniffMultiplex();
                     $this->multiplex = $this->_properties['properties'][self::MULTIPLEX];
                     $this->save();
+                } elseif (!$this->_multiplexSet
+                    && $this->_isIos()
+                    && ($this->_properties['properties'][self::MULTIPLEX] & self::MULTIPLEX_NOTES)) {
+                    $this->multiplex = $this->_properties['properties'][self::MULTIPLEX] & ~self::MULTIPLEX_NOTES;
+                    $this->save(false);
                 }
                 // no break
             case self::ANNOUNCED_VERSION:
@@ -765,8 +770,8 @@ class Horde_ActiveSync_Device
     {
         $clientType = Horde_String::lower($this->clientType);
         if ($this->_isIos()) {
-            // iOS seems to support multiple collections for everything except Notes.
-            $this->_properties['properties'][self::MULTIPLEX] = Horde_ActiveSync_Device::MULTIPLEX_NOTES;
+            // Modern iOS versions support multiple Notes collections, however the collection managment is better done via web (app offers no functionbality)
+            $this->_properties['properties'][self::MULTIPLEX] = 0;
         } elseif ($clientType == self::TYPE_ANDROID) {
             // Special cases: These clients don't support non-multiplexed
             // collections. Samsung's native client and HTCOnemini2.

--- a/test/Horde/ActiveSync/DeviceTest.php
+++ b/test/Horde/ActiveSync/DeviceTest.php
@@ -33,7 +33,18 @@ class DeviceTest extends TestCase
         $this->assertEquals(7, $device->getMajorVersion());
         $this->assertEquals(0, $device->getMinorVersion());
         $this->assertEquals(Horde_ActiveSync_Device::TYPE_IPOD, Horde_String::lower($device->deviceType));
-        $this->assertEquals(Horde_ActiveSync_Device::MULTIPLEX_NOTES, $device->multiplex);
+        $this->assertEquals(0, $device->multiplex);
+
+        $fixture = [
+            'deviceType' => 'iPhone',
+            'userAgent' => 'Apple-iPhone6C1/1104.201',
+            'properties' => [
+                Horde_ActiveSync_Device::OS => 'iOS 26.0',
+                Horde_ActiveSync_Device::MULTIPLEX => Horde_ActiveSync_Device::MULTIPLEX_NOTES,
+            ],
+        ];
+        $device = new Horde_ActiveSync_Device($state, $fixture);
+        $this->assertEquals(0, $device->multiplex);
 
         $fixture = [
             'deviceType' => 'iPhone',
@@ -43,7 +54,7 @@ class DeviceTest extends TestCase
         $this->assertEquals(6, $device->getMajorVersion());
         $this->assertEquals(1, $device->getMinorVersion());
         $this->assertEquals(Horde_ActiveSync_Device::TYPE_IPHONE, Horde_String::lower($device->deviceType));
-        $this->assertEquals(Horde_ActiveSync_Device::MULTIPLEX_NOTES, $device->multiplex);
+        $this->assertEquals(0, $device->multiplex);
         $this->assertEquals(false, $device->hasQuirk(Horde_ActiveSync_Device::QUIRK_NEEDS_SUPPORTED_PICTURE_TAG));
 
         $fixture = [
@@ -64,7 +75,7 @@ class DeviceTest extends TestCase
         $this->assertEquals(8, $device->getMajorVersion());
         $this->assertEquals(1, $device->getMinorVersion());
         $this->assertEquals(Horde_ActiveSync_Device::TYPE_IPAD, Horde_String::lower($device->deviceType));
-        $this->assertEquals(Horde_ActiveSync_Device::MULTIPLEX_NOTES, $device->multiplex);
+        $this->assertEquals(0, $device->multiplex);
 
         $fixture = [
             'deviceType' => 'iPad',
@@ -75,7 +86,7 @@ class DeviceTest extends TestCase
         $this->assertEquals(8, $device->getMajorVersion());
         $this->assertEquals(3, $device->getMinorVersion());
         $this->assertEquals(Horde_ActiveSync_Device::TYPE_IPAD, Horde_String::lower($device->deviceType));
-        $this->assertEquals(Horde_ActiveSync_Device::MULTIPLEX_NOTES, $device->multiplex);
+        $this->assertEquals(0, $device->multiplex);
 
         $fixture = [
             'deviceType' => 'iPhone',
@@ -86,7 +97,7 @@ class DeviceTest extends TestCase
         $this->assertEquals(9, $device->getMajorVersion());
         $this->assertEquals(0, $device->getMinorVersion());
         $this->assertEquals(Horde_ActiveSync_Device::TYPE_IPHONE, Horde_String::lower($device->deviceType));
-        $this->assertEquals(Horde_ActiveSync_Device::MULTIPLEX_NOTES, $device->multiplex);
+        $this->assertEquals(0, $device->multiplex);
 
 
         // Old Android.


### PR DESCRIPTION
historic iOS did not support nultiple note collections, therfore multiplexing was enforced. No longer necessary with nowadays iOS