### PR TITLE
Fix/activesync for kronolith

### DIFF
--- a/lib/Horde/ActiveSync/Connector/Exporter/Sync.php
+++ b/lib/Horde/ActiveSync/Connector/Exporter/Sync.php
@@ -401,7 +401,9 @@ class Horde_ActiveSync_Connector_Exporter_Sync extends Horde_ActiveSync_Connecto
                 $atc = $this->_as->messageFactory('AirSyncBaseAttachment');
                 $atc->clientid = $clientid;
                 $atc->attname = $filereference;
-                $msg->airsyncbaseattachments[] = $atc;
+                $attachments = $msg->airsyncbaseattachments;
+                $attachments[] = $atc;
+                $msg->airsyncbaseattachments = $attachments;
             }
             $this->_encoder->startTag(Horde_ActiveSync::SYNC_DATA);
             $msg->encodeStream($this->_encoder);

--- a/lib/Horde/ActiveSync/Connector/Importer.php
+++ b/lib/Horde/ActiveSync/Connector/Importer.php
@@ -362,6 +362,10 @@ class Horde_ActiveSync_Connector_Importer
             }
         );
         $collections = $this->_as->getCollectionsObject();
+        $collectionClass = $class ?: $collections->getCollectionClass($this->_folderUid);
+        if (empty($collectionClass) || $collectionClass == 'RI') {
+            $collectionClass = Horde_ActiveSync::CLASS_EMAIL;
+        }
         $dst = $collections->getBackendIdForFolderUid($dst);
         $results = $this->_as->driver->moveMessage($this->_folderId, $uids, $dst);
 
@@ -383,7 +387,7 @@ class Horde_ActiveSync_Connector_Importer
             $change['id'] = $results[$uid];
             $change['mod'] = $mod;
             $change['serverid'] = $dst;
-            $change['class'] = Horde_ActiveSync::CLASS_EMAIL;
+            $change['class'] = $collectionClass;
             $change['folderuid'] = $this->_folderUid;
             $this->_state->updateState(
                 Horde_ActiveSync::CHANGE_TYPE_CHANGE,

--- a/lib/Horde/ActiveSync/Connector/Importer.php
+++ b/lib/Horde/ActiveSync/Connector/Importer.php
@@ -488,7 +488,7 @@ class Horde_ActiveSync_Connector_Importer
         $this->_state->updateState(
             Horde_ActiveSync::CHANGE_TYPE_DELETE,
             $change,
-            Horde_ActiveSync::CHANGE_ORIGIN_NA
+            Horde_ActiveSync::CHANGE_ORIGIN_PIM
         );
     }
 

--- a/lib/Horde/ActiveSync/Message/Base.php
+++ b/lib/Horde/ActiveSync/Message/Base.php
@@ -482,11 +482,15 @@ class Horde_ActiveSync_Message_Base
                     }
 
                     // Assign the parsed value to the mapped attribute.
-                    if (!isset($this->{$map[self::KEY_ATTRIBUTE]})) {
-                        $this->{$map[self::KEY_ATTRIBUTE]} = [$decoded];
-                    } else {
-                        $this->{$map[self::KEY_ATTRIBUTE]}[] = $decoded;
+                    $attribute = $map[self::KEY_ATTRIBUTE];
+                    $values = isset($this->{$attribute})
+                        ? $this->{$attribute}
+                        : [];
+                    if (!is_array($values)) {
+                        $values = [];
                     }
+                    $values[] = $decoded;
+                    $this->{$attribute} = $values;
 
                     // Get the end tag of this attribute node.
                     if (!$decoder->getElementEndTag()) {

--- a/lib/Horde/ActiveSync/Request/FolderCreate.php
+++ b/lib/Horde/ActiveSync/Request/FolderCreate.php
@@ -220,8 +220,6 @@ class Horde_ActiveSync_Request_FolderCreate extends Horde_ActiveSync_Request_Bas
             $this->_encoder->endTag();
         }
 
-        $this->_encoder->endTag();
-
         if ($status == self::STATUS_SUCCESS) {
             $this->_state->setNewSyncKey($newsynckey);
             $this->_state->save();


### PR DESCRIPTION
# Fix ActiveSync calendar folder, MoveItems, and EAS 16 attachment handling

## Summary

- Treat client-side `FolderDelete` as a PIM-originated change when updating folder state.
- Remove an extra WBXML `endTag()` from the shared FolderCreate/FolderUpdate/FolderDelete request handler.
- Preserve the source collection class when recording `MoveItems` state, so calendar moves are not tracked as mail moves.
- Fix generic decoding of array-valued ActiveSync message properties that are backed by magic properties.
- Return EAS 16.0 calendar attachment `FileReference` values in `Sync` modify responses.

## Problem

This PR collects several protocol-level ActiveSync fixes found while testing Kronolith with iOS devices using EAS 16.0.

The issues were independent, but they all affected calendar folder or appointment behavior:

- Deleting a calendar folder from iOS completed at protocol level but caused Horde warnings during state handling and WBXML response encoding.
- Moving an appointment between calendars from iOS worked in the calendar backend, but then failed while writing ActiveSync state because the moved calendar event was classified as email.
- Adding an attachment to an appointment from iOS sent valid EAS 16.0 `AirSyncBase:Add` data, but the attachment was not persisted in Kronolith and was not propagated to other devices.

Web-side Kronolith operations already worked in the tested cases; the failures were specific to client-originated ActiveSync requests and follow-up state/response handling.

## Solution

### FolderDelete state origin

`Horde_ActiveSync_Connector_Importer::importFolderDeletion()` now updates state with `CHANGE_ORIGIN_PIM`.

`FolderDelete` is initiated by the client, so it must use the client-originated state path. Previously it used `CHANGE_ORIGIN_NA`, which sent SQL state handling down the server-change bookkeeping path where pending changes can be `null` for this request.

This avoids warnings like:

```text
foreach() argument must be of type array|object, null given
```

### FolderDelete WBXML response balance

`Horde_ActiveSync_Request_FolderCreate` handles FolderCreate, FolderUpdate, and FolderDelete. Each response branch opens and closes its own root response tag.

The method had one additional unconditional `endTag()` after the branch. For FolderDelete this could pop an empty encoder stack after a valid response had already been produced.

The extra unconditional `endTag()` was removed.

### Calendar MoveItems state classification

`Horde_ActiveSync_Connector_Importer::importMessageMove()` no longer records all `MoveItems` changes as email.

It now resolves the source collection class:

- use the explicit `$class` parameter when supplied,
- otherwise read the class from the source collection,
- fall back to `Email` if no class can be resolved.

This fixes calendar moves from iOS. Calendar event UIDs are strings, but the mail map table expects integer mail UIDs. Classifying a calendar move as email caused PostgreSQL errors such as:

```text
SQLSTATE[22003]: Numeric value out of range
```

Calendar moves are now tracked as calendar/PIM changes in the general ActiveSync map table. Mail `MoveItems` behavior remains unchanged.

### Generic array-property decode fix

`Horde_ActiveSync_Message_Base::decodeStream()` now assigns decoded array-valued child elements with explicit read-modify-write logic.

The old decoder appended to a magic property directly:

```php
$this->{$attribute}[] = $decoded;
```

For properties backed by `__get()` / `__set()`, that append can operate on a temporary value and not update the message object's internal property array.

The decoder now reads the current value, appends locally, and writes the full array back through `__set()`.

This is a generic fix for mapped array containers, and it is required for EAS 16 calendar attachments because incoming:

```text
AirSyncBase:Attachments / AirSyncBase:Add
```

must be preserved in the decoded appointment message before Kronolith can store the file.

### Calendar attachment FileReference response

`Horde_ActiveSync_Connector_Exporter_Sync::_sendEas16MessageResponse()` now also uses explicit read-modify-write when adding attachment response objects to an appointment message.

After an iOS client uploads an EAS 16.0 appointment attachment, the server must return a `ClientId -> FileReference` mapping in the `Sync` modify response. Without that response, the originating client does not receive the committed server-side attachment reference and other clients cannot fetch the attachment.

The response now includes the attachment metadata needed by EAS 16 clients.

## Files changed

### `lib/Horde/ActiveSync/Connector/Importer.php`

- Uses `CHANGE_ORIGIN_PIM` for client-originated folder deletion state updates.
- Resolves the source collection class for `MoveItems`.
- Stores calendar `MoveItems` state as calendar/PIM state instead of mail state.

### `lib/Horde/ActiveSync/Request/FolderCreate.php`

- Removes the extra unconditional WBXML `endTag()` after FolderCreate/FolderUpdate/FolderDelete response generation.

### `lib/Horde/ActiveSync/Message/Base.php`

- Fixes array-valued property assignment during message decoding by using explicit read-modify-write.
- Ensures decoded multi-value children such as EAS 16 attachment actions are preserved in the message object.

### `lib/Horde/ActiveSync/Connector/Exporter/Sync.php`

- Fixes EAS 16 calendar `Sync` modify responses so attachment response objects are actually added to the appointment message.
- Allows clients to receive the server `FileReference` for newly uploaded appointment attachments.

## Validation

- `php -l` completed successfully for the edited ActiveSync PHP files.
- Cursor/IDE lints reported no errors for the edited ActiveSync files.
- Manual iOS EAS 16.0 testing confirmed FolderDelete returns success without the previous Horde warnings.
- Manual iOS EAS 16.0 testing confirmed moving appointments between calendars works and no longer writes calendar UIDs to `horde_activesync_mailmap`.
- Manual iOS EAS 16.0 testing confirmed adding an attachment to an appointment now works and propagates correctly.

## Test plan

- [x] Delete an ActiveSync calendar folder from iOS and confirm FolderDelete returns status `1`.
- [x] Confirm `/tmp-horde/horde.log` no longer logs `foreach() argument must be of type array|object, null given` during FolderDelete.
- [x] Confirm `/tmp-horde/horde.log` no longer logs WBXML encoder stack warnings during FolderDelete.
- [x] Move an appointment between calendars from Kronolith web UI and confirm it syncs to iOS.
- [x] Move an appointment between calendars from iOS and confirm it is visible in Kronolith web UI.
- [x] Confirm the iOS calendar move no longer causes `horde_activesync_mailmap.message_uid` integer overflow errors.
- [x] Add an attachment to an existing appointment from iOS.
- [x] Confirm the attachment is persisted and appears in Kronolith.
- [x] Confirm the attachment is visible to another iOS device.
- [x] Confirm the EAS 16.0 modify response includes the attachment `FileReference`.

## Notes

These changes are ActiveSync-core fixes. They are not Kronolith-specific API changes, but they were discovered while stabilizing Kronolith calendar folders, appointment moves, and appointment attachments with iOS EAS 16.0.

The changes are intended to preserve existing mail behavior while fixing calendar/PIM paths that were incorrectly handled as mail or lost through magic-property array mutation.
