### PR TITLE
Enhance attendee parameter validation

### DIFF
--- a/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
+++ b/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
@@ -473,11 +473,12 @@ class Horde_ActiveSync_Imap_EasMessageBuilder
                         throw new Horde_ActiveSync_Exception($e);
                     }
 
-                    if (!is_array($atparams)) {
+                    if (!is_array($atparams) || !isset($atparams[0])) {
                         throw new Horde_Icalendar_Exception('Unexpected value');
                     }
 
-                    return $atparams[0]['PARTSTAT'];
+                    // PARTSTAT is optional on ATTENDEE (RFC 5545 default: NEEDS-ACTION).
+                    return $atparams[0]['PARTSTAT'] ?? 'NEEDS-ACTION';
             }
         }
     }


### PR DESCRIPTION
# Fix undefined array key warnings for optional `PARTSTAT` on meeting replies

## Summary

- Guard access to `PARTSTAT` on the first `ATTENDEE` parameter set in `_getiTipStatus()`.
- Default to `NEEDS-ACTION` when `PARTSTAT` is omitted, per RFC 5545.
- Validate that `getAttribute('ATTENDEE', true)` returns a non-empty parameter list before indexing.

## Problem

For calendar messages with `METHOD:REPLY`, `_populateiTip()` calls `_getiTipStatus()` to map the attendee participation status to an Exchange message class (`IPM.Schedule.Meeting.Resp.Pos` / `.Neg` / `.Tent`).

`_getiTipStatus()` always reads `$atparams[0]['PARTSTAT']` after loading attendee parameters. `PARTSTAT` is an optional property parameter on `ATTENDEE`; some clients send replies without it, for example:

```
METHOD:REPLY
BEGIN:VEVENT
ATTENDEE;CN=User:mailto:user@example.com
END:VEVENT
```

On PHP 8+, accessing a missing key emits:

```
PHP ERROR: Undefined array key "PARTSTAT"
```

This appears in Horde logs when ActiveSync exports mail that contains an iTIP `REPLY` with an `ATTENDEE` line but no `PARTSTAT=...` parameter (seen on line 480 of `Horde_ActiveSync_Imap_EasMessageBuilder`).

## Solution

Return the first attendee’s `PARTSTAT` when present; otherwise use the RFC 5545 default `NEEDS-ACTION`:

```php
if (!is_array($atparams) || !isset($atparams[0])) {
    throw new Horde_Icalendar_Exception('Unexpected value');
}

// PARTSTAT is optional on ATTENDEE (RFC 5545 default: NEEDS-ACTION).
return $atparams[0]['PARTSTAT'] ?? 'NEEDS-ACTION';
```

Replies that include `PARTSTAT=ACCEPTED`, `DECLINED`, or `TENTATIVE` behave as before. Replies without `PARTSTAT` no longer warn; they do not match the accept/decline/tentative switch cases (same as an explicit `NEEDS-ACTION`), so `messageclass` is left unset for those messages.

## Test plan

- [ ] Sync or fetch a mail message whose embedded calendar part uses `METHOD:REPLY` and `ATTENDEE` without `PARTSTAT`; confirm no `Undefined array key "PARTSTAT"` in Horde logs.
- [ ] Verify `METHOD:REPLY` with `PARTSTAT=ACCEPTED`, `DECLINED`, and `TENTATIVE` still sets `messageclass` to `IPM.Schedule.Meeting.Resp.Pos`, `.Neg`, and `.Tent` respectively.
- [ ] Verify `METHOD:REQUEST` / `PUBLISH` meeting invitations are unchanged (they do not call `_getiTipStatus()`).
- [ ] Optional: run ActiveSync unit tests if available in the package test suite.
