### PR TITLE
Fix/method handling

### DIFF
--- a/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
+++ b/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\HordeString;
+
 /**
  * @license   http://www.horde.org/licenses/gpl GPLv2
  *
@@ -232,8 +234,8 @@ class Horde_ActiveSync_Imap_EasMessageBuilder
         // Flags
         $flags = [];
         foreach ($this->_imapMessage->getFlags() as $flag) {
-            if (!empty($msgFlags[Horde_String::lower($flag)])) {
-                $flags[] = $msgFlags[Horde_String::lower($flag)];
+            if (!empty($msgFlags[HordeString::lower($flag)])) {
+                $flags[] = $msgFlags[HordeString::lower($flag)];
             }
         }
         $this->_easMessage->categories = $flags;
@@ -327,7 +329,7 @@ class Horde_ActiveSync_Imap_EasMessageBuilder
         }
 
         // Many senders omit METHOD on text/calendar parts; treat as REQUEST (Bug #12083).
-        $method = Horde_String::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
+        $method = HordeString::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
         $this->_easMessage->contentclass = 'urn:content-classes:calendarmessage';
 
         switch ($method) {
@@ -436,7 +438,7 @@ class Horde_ActiveSync_Imap_EasMessageBuilder
      */
     protected function _getEASImportance($importance)
     {
-        switch (Horde_String::lower($importance)) {
+        switch (HordeString::lower($importance)) {
             case '1':
             case 'high':
                 return 2;

--- a/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
+++ b/lib/Horde/ActiveSync/Imap/EasMessageBuilder.php
@@ -326,13 +326,9 @@ class Horde_ActiveSync_Imap_EasMessageBuilder
             return;
         }
 
-        try {
-            $method = $vCal->getAttribute('METHOD');
-            $this->_easMessage->contentclass = 'urn:content-classes:calendarmessage';
-        } catch (Horde_Icalendar_Exception $e) {
-            $this->_logger->err($e->getMessage());
-            return;
-        }
+        // Many senders omit METHOD on text/calendar parts; treat as REQUEST (Bug #12083).
+        $method = Horde_String::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
+        $this->_easMessage->contentclass = 'urn:content-classes:calendarmessage';
 
         switch ($method) {
             case 'REQUEST':

--- a/lib/Horde/ActiveSync/Message/MeetingRequest.php
+++ b/lib/Horde/ActiveSync/Message/MeetingRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\HordeString;
+
 /**
  * Portions of this class were ported from the Z-Push project:
  *   File      :   wbxml.php
@@ -126,7 +128,7 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
      */
     public function fromvEvent($vCal)
     {
-        $method = Horde_String::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
+        $method = HordeString::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
         foreach ($vCal->getComponents() as $component) {
             switch ($component->getType()) {
                 case 'vEvent':
@@ -203,7 +205,7 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
 
         try {
             $this->endtime = new Horde_Date($vevent->getAttribute('DTEND'));
-            $this->location = Horde_String::truncate($vevent->getAttribute('LOCATION'), 255);
+            $this->location = HordeString::truncate($vevent->getAttribute('LOCATION'), 255);
         } catch (Horde_Icalendar_Exception $e) {
         }
 
@@ -222,7 +224,7 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
         try {
             $status = $vevent->getAttribute('STATUS');
             if (!is_array($status)) {
-                $status = Horde_String::upper($status);
+                $status = HordeString::upper($status);
                 $this->busystatus = $status == 'TENTATIVE' ? Horde_ActiveSync_Message_Appointment::BUSYSTATUS_TENTATIVE
                     : ($status == 'CONFIRMED' ? Horde_ActiveSync_Message_Appointment::BUSYSTATUS_BUSY
                         : Horde_ActiveSync_Message_Appointment::BUSYSTATUS_FREE);

--- a/lib/Horde/ActiveSync/Message/MeetingRequest.php
+++ b/lib/Horde/ActiveSync/Message/MeetingRequest.php
@@ -126,11 +126,7 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
      */
     public function fromvEvent($vCal)
     {
-        try {
-            $method = $vCal->getAttribute('METHOD');
-        } catch (Horde_Icalendar_Exception $e) {
-            throw new Horde_ActiveSync_Exception('Unable to parse vEvent');
-        }
+        $method = Horde_String::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
         foreach ($vCal->getComponents() as $component) {
             switch ($component->getType()) {
                 case 'vEvent':

--- a/lib/Horde/ActiveSync/Message/MeetingRequest.php
+++ b/lib/Horde/ActiveSync/Message/MeetingRequest.php
@@ -262,7 +262,6 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
                 $this->reminder = -intval($trigger);
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
# Default missing iCalendar `METHOD` when exporting meeting mail over ActiveSync

## Summary

- Use `getAttributeDefault('METHOD', 'REQUEST')` instead of `getAttribute('METHOD')` in `Horde_ActiveSync_Imap_EasMessageBuilder::_meetingRequest()` so calendar MIME parts without a `METHOD` property are still exported as meeting messages.
- Apply the same default in `Horde_ActiveSync_Message_MeetingRequest::fromvEvent()` so meeting request fields (times, location, `responserequested`, etc.) are populated instead of failing with `Unable to parse vEvent`.
- Normalize the method with `Horde_String::upper()` before the existing `switch`, so mixed-case values from senders still match `REQUEST`, `REPLY`, and `PUBLISH`.

## Problem

Many real-world `text/calendar` attachments include a valid `VEVENT` but omit the top-level `METHOD` property (RFC 5546 recommends it, but Apple Mail, some webmail systems, and older generators often leave it out).

ActiveSync treated a missing `METHOD` as fatal:

1. **`EasMessageBuilder::_meetingRequest()`** called `getAttribute('METHOD')`, logged `Attribute "METHOD" Not Found`, and returned early. The mail synced without `contentclass`, `messageclass`, or a `MeetingRequest` block for the client.
2. **`MeetingRequest::fromvEvent()`** caught the same exception and threw `Horde_ActiveSync_Exception('Unable to parse vEvent')` even when `DTSTART`, `ORGANIZER`, and other required event data were present.

This regressed behavior that was fixed upstream as [Bug #12083](https://bugs.horde.org/12083) (“synchronizing email messages containing ICalendar attachments with no METHOD parameter”) but is strict again in current `FRAMEWORK_6_0` code.

Other Horde apps already tolerate missing `METHOD`:

- `Horde_Itip_Event_Vevent::getMethod()` uses `getAttributeDefault('METHOD', 'REQUEST')`.
- IMP’s `Horde_Imp_Mime_Viewer_Itip` catches the exception and continues with an empty method string.

ActiveSync was the outlier, which produced noisy logs and degraded meeting-invite handling on EAS clients (e.g. iOS Mail).

## Solution

### `lib/Horde/ActiveSync/Imap/EasMessageBuilder.php`

Replace the `try` / `catch` / `return` around `getAttribute('METHOD')` with:

```php
$method = Horde_String::upper($vCal->getAttributeDefault('METHOD', 'REQUEST'));
$this->_easMessage->contentclass = 'urn:content-classes:calendarmessage';
```

The existing `switch ($method)` for `REQUEST` / `PUBLISH` (meeting request) and `REPLY` (meeting response) is unchanged. Calendar classification no longer depends on an optional property that is frequently absent.

### `lib/Horde/ActiveSync/Message/MeetingRequest.php`

Replace the `try` / `catch` that mapped a missing `METHOD` to `Unable to parse vEvent` with the same default and normalization. `_parsevEvent()` already defaults `$method` to `'REQUEST'` and sets `responserequested` to `1` for requests; missing `METHOD` now reaches that path consistently.

### Why `REQUEST` as the default

Mail with a `VEVENT` and no `METHOD` is most often an invitation. Defaulting to `REQUEST` matches `Horde_Itip`, aligns with `_parsevEvent()`’s parameter default, and routes the message through the existing `REQUEST` / `PUBLISH` branch in `EasMessageBuilder`.

**Known limitation:** A true `REPLY` without a `METHOD` line may be exported as a meeting request. That case is uncommon; inferring `REPLY` from `ATTENDEE` / `PARTSTAT` would be a separate, heuristic change.

## Files changed

| File | Change |
|------|--------|
| `lib/Horde/ActiveSync/Imap/EasMessageBuilder.php` | Default `METHOD`; do not abort `_meetingRequest()` |
| `lib/Horde/ActiveSync/Message/MeetingRequest.php` | Default `METHOD` in `fromvEvent()` |

Local patch file (for deployments): `patches/horde-activesync-icalendar-method-default.patch`

## Related work

- Horde ActiveSync changelog: Bug #12083 (2.3.0 era).
- `Horde_Itip_Event_Vevent::getMethod()` — same default.
- Independent issue: Dovecot / malformed quoted-printable mail bodies breaking IMAP `FETCH` (not addressed by this PR).

## Test plan

- [ ] Sync a message with `text/calendar` containing `BEGIN:VEVENT` / `DTSTART` / `ORGANIZER` but **no** `METHOD:` line via an EAS client; confirm no `Attribute "METHOD" Not Found` in ActiveSync logs.
- [ ] Confirm the same message exports with `contentclass` `urn:content-classes:calendarmessage` and meeting request metadata (start/end, organizer where present).
- [ ] Sync a standard invitation with `METHOD:REQUEST`; behavior unchanged (accept/decline UI where the client supports it).
- [ ] Sync a `METHOD:REPLY` message with `PARTSTAT=ACCEPTED` / `DECLINED` / `TENTATIVE`; confirm correct `IPM.Schedule.Meeting.Resp.*` `messageclass`.
- [ ] Sync a `METHOD:PUBLISH` event; still treated as a meeting request per existing `switch`.
- [ ] Sync a non-calendar mail; `_meetingRequest()` still exits early when no iCalendar part is present (no regression).
