### PR TITLE
refactor/followup to pr 40

### DIFF
--- a/lib/Horde/ActiveSync/Device.php
+++ b/lib/Horde/ActiveSync/Device.php
@@ -182,7 +182,9 @@ class Horde_ActiveSync_Device
                 }
                 break;
             case self::OS:
-                return $this->_properties['properties'][self::OS] ? $this->_properties['properties'][self::OS] : '';
+                if (isset($this->_properties['properties'][self::OS])) {
+                    return $this->_properties['properties'][self::OS];
+                }
                 break;
             case 'properties':
                 if (!isset($this->_properties['properties'])) {

--- a/lib/Horde/ActiveSync/Mime/Iterator.php
+++ b/lib/Horde/ActiveSync/Mime/Iterator.php
@@ -143,18 +143,18 @@ class Horde_ActiveSync_Mime_Iterator implements Countable, Iterator
 
     /**
      */
-    #[\ReturnTypeWillChange]
-    public function next() 
+    public function next(): void
     {
         if (!isset($this->_state)) {
-            return null;
+            return;
         }
 
         $out = $this->_state->current->getPartByIndex($this->_state->index++);
         if ($out) {
             if (($this->_ignoreAttachments && $this->_isAttachment($out))
                 || !$this->_allowRecursion($this->_state->current)) {
-                return $this->next();
+                $this->next();
+                return;
             }
             $this->_state->recurse[] = [
                 $this->_state->current,


### PR DESCRIPTION
The necessary followup mentioned in #40 - PHP 8.6 is going to be out in July and return+next oneliner was a logical mistake anyway.

- **fix(Device): restore isset guard for OS property access**
- **fix(Iterator): use void return type for next() instead of ReturnTypeWillChange**
