### PR TITLE
feat(activesync): add EAS 16.0 Find command support

### DIFF
--- a/lib/Horde/ActiveSync.php
+++ b/lib/Horde/ActiveSync.php
@@ -1112,7 +1112,7 @@ class Horde_ActiveSync
             case self::VERSION_FOURTEEN:
             case self::VERSION_FOURTEENONE:
             case self::VERSION_SIXTEEN:
-                return 'Sync,SendMail,SmartForward,SmartReply,GetAttachment,GetHierarchy,CreateCollection,DeleteCollection,MoveCollection,FolderSync,FolderCreate,FolderDelete,FolderUpdate,MoveItems,GetItemEstimate,MeetingResponse,Search,Settings,Ping,ItemOperations,Provision,ResolveRecipients,ValidateCert';
+                return 'Sync,SendMail,SmartForward,SmartReply,GetAttachment,GetHierarchy,CreateCollection,DeleteCollection,MoveCollection,FolderSync,FolderCreate,FolderDelete,FolderUpdate,MoveItems,GetItemEstimate,MeetingResponse,Search,Settings,Ping,ItemOperations,Provision,ResolveRecipients,ValidateCert,Find';
         }
     }
 

--- a/lib/Horde/ActiveSync/Driver/Base.php
+++ b/lib/Horde/ActiveSync/Driver/Base.php
@@ -538,6 +538,23 @@ abstract class Horde_ActiveSync_Driver_Base
     abstract public function getSearchResults(Horde_ActiveSync_Search_Params $params): Horde_ActiveSync_Search_Results;
 
     /**
+     * Returns Find command results for the given parameters.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_ActiveSync_Find_Params $params     The find parameters.
+     * @param array                        $bodyprefs    Body preference options.
+     * @param integer                      $mimesupport  MIME support flag.
+     *
+     * @return Horde_ActiveSync_Find_Results
+     */
+    abstract public function getFindResults(
+        Horde_ActiveSync_Find_Params $params,
+        array $bodyprefs = [],
+        $mimesupport = 0
+    ): Horde_ActiveSync_Find_Results;
+
+    /**
      * Stat folder. Note that since the only thing that can ever change for a
      * folder is the name, we use that as the 'mod' value.
      *

--- a/lib/Horde/ActiveSync/Driver/Mock.php
+++ b/lib/Horde/ActiveSync/Driver/Mock.php
@@ -103,7 +103,25 @@ class Horde_ActiveSync_Driver_Mock extends Horde_ActiveSync_Driver_Base
      */
     public function getSearchResults(Horde_ActiveSync_Search_Params $params): Horde_ActiveSync_Search_Results
     {
-        return [];
+        return new Horde_ActiveSync_Search_Results(0, [], 0);
+    }
+
+    /**
+     * Returns Find command results for the given parameters.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     */
+    public function getFindResults(
+        Horde_ActiveSync_Find_Params $params,
+        array $bodyprefs = [],
+        $mimesupport = 0
+    ): Horde_ActiveSync_Find_Results {
+        return new Horde_ActiveSync_Find_Results(
+            Horde_ActiveSync_Request_Find::STATUS_SUCCESS,
+            Horde_ActiveSync_Request_Find::STORE_STATUS_SUCCESS,
+            0,
+            []
+        );
     }
 
     /**

--- a/lib/Horde/ActiveSync/Find/Kql.php
+++ b/lib/Horde/ActiveSync/Find/Kql.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Horde_ActiveSync_Find_Kql
+ *
+ * Minimal KQL parser for EAS 16.0 Find mailbox searches.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+
+/**
+ * Parse a subset of Keyword Query Language used by EAS Find requests.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Find_Kql
+{
+    /**
+     * Parse KQL / free-text into an IMAP search query.
+     *
+     * @param string $text  Raw query string from the client.
+     *
+     * @return Horde_Imap_Client_Search_Query
+     */
+    public static function toImapQuery(string $text): Horde_Imap_Client_Search_Query
+    {
+        $text = trim($text);
+        $query = new Horde_Imap_Client_Search_Query();
+        $query->charset('UTF-8', false);
+
+        if ($text === '') {
+            return $query;
+        }
+
+        if (preg_match('/\s+OR\s+/i', $text)) {
+            $parts = preg_split('/\s+OR\s+/i', $text);
+            $queries = [];
+            foreach ($parts as $part) {
+                $part = trim($part);
+                if ($part !== '') {
+                    $queries[] = self::_parseClause($part);
+                }
+            }
+            if (count($queries) > 1) {
+                $query->orSearch($queries);
+
+                return $query;
+            }
+            if (count($queries) === 1) {
+                return $queries[0];
+            }
+        }
+
+        return self::_parseClause($text);
+    }
+
+    /**
+     * Parse a single KQL clause (no OR).
+     *
+     * @param string $text  One clause from a Find FreeText string.
+     *
+     * @return Horde_Imap_Client_Search_Query
+     */
+    protected static function _parseClause(string $text): Horde_Imap_Client_Search_Query
+    {
+        $text = trim($text);
+        $query = new Horde_Imap_Client_Search_Query();
+        $query->charset('UTF-8', false);
+
+        if (preg_match('/^\s*(from|to|cc|bcc|subject)\s*:\s*("([^"]+)"|(\S+))\s*$/i', $text, $m)) {
+            $value = !empty($m[3]) ? $m[3] : $m[4];
+            $query->headerText(Horde_String::lower($m[1]), $value, false);
+
+            return $query;
+        }
+
+        if (preg_match('/^"([^"]+)"$/', $text, $m)) {
+            $query->text($m[1], false);
+
+            return $query;
+        }
+
+        if (preg_match('/^hasattachment:\s*(yes|true|1)$/i', $text)) {
+            $query->text('multipart', false);
+
+            return $query;
+        }
+
+        if (preg_match('/^received\s*(>=|<=|>|<|:)\s*(\d{4}-\d{2}-\d{2})/i', $text, $m)) {
+            $date = new Horde_Date($m[2], 'UTC');
+            $op = $m[1];
+            if ($op === '>=' || $op === '>') {
+                $query->dateSearch($date, Horde_Imap_Client_Search_Query::DATE_SINCE);
+            } elseif ($op === '<=' || $op === '<') {
+                $query->dateSearch($date, Horde_Imap_Client_Search_Query::DATE_BEFORE);
+            } else {
+                $query->dateSearch($date, Horde_Imap_Client_Search_Query::DATE_ON);
+            }
+
+            return $query;
+        }
+
+        $query->text($text, false);
+
+        return $query;
+    }
+}

--- a/lib/Horde/ActiveSync/Find/Params.php
+++ b/lib/Horde/ActiveSync/Find/Params.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Horde_ActiveSync_Find_Params
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+
+/**
+ * Parameters for an EAS Find command request.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Find_Params
+{
+    /**
+     * @param string      $type           One of 'mailbox' or 'gal'.
+     * @param string|null $searchId       Client-provided search session id.
+     * @param array       $query          Parsed query (freetext, class, collectionid).
+     * @param array       $options        Options (picture, etc.).
+     * @param int         $start          Result range start.
+     * @param int         $limit          Maximum results to return.
+     * @param bool        $deepTraversal  Search subfolders when true.
+     */
+    public function __construct(
+        public string $type,
+        public ?string $searchId,
+        public array $query,
+        public array $options,
+        public int $start,
+        public int $limit,
+        public bool $deepTraversal,
+    ) {}
+}

--- a/lib/Horde/ActiveSync/Find/QueryMapper.php
+++ b/lib/Horde/ActiveSync/Find/QueryMapper.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Horde_ActiveSync_Find_QueryMapper
+ *
+ * Maps EAS Find command parameters to Search command parameters so both
+ * commands share the same IMAP/GAL backend.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Find_QueryMapper
+{
+    /**
+     * Convert Find parameters into the structure expected by
+     * Horde_Core_ActiveSync_Driver::getSearchResults().
+     *
+     * @param Horde_ActiveSync_Find_Params $params  Parsed Find request.
+     *
+     * @return Horde_ActiveSync_Search_Params
+     */
+    public static function toSearchParams(
+        Horde_ActiveSync_Find_Params $params
+    ): Horde_ActiveSync_Search_Params {
+        $type = Horde_String::lower($params->type);
+
+        if ($type === 'gal') {
+            $text = $params->query['text']
+                ?? $params->query['freetext']
+                ?? '';
+
+            return new Horde_ActiveSync_Search_Params(
+                type: 'gal',
+                query: [$text],
+                options: $params->options,
+                start: $params->start,
+                limit: $params->limit,
+                rebuildResults: false,
+                deepTraversal: false,
+            );
+        }
+
+        $criteria = [];
+        if (!empty($params->query['class'])) {
+            $criteria['FolderType'] = $params->query['class'];
+        }
+        if (!empty($params->query['serverid'])) {
+            $criteria['serverid'] = $params->query['serverid'];
+        }
+        if (!empty($params->query['freetext'])) {
+            $criteria[Horde_ActiveSync_Request_Search::SEARCH_FREETEXT]
+                = $params->query['freetext'];
+        }
+
+        return new Horde_ActiveSync_Search_Params(
+            type: 'mailbox',
+            query: [
+                [
+                    'op' => Horde_ActiveSync_Request_Search::SEARCH_AND,
+                    'value' => $criteria,
+                ],
+            ],
+            options: $params->options,
+            start: $params->start,
+            limit: $params->limit,
+            rebuildResults: false,
+            deepTraversal: $params->deepTraversal,
+        );
+    }
+}

--- a/lib/Horde/ActiveSync/Find/Results.php
+++ b/lib/Horde/ActiveSync/Find/Results.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Horde_ActiveSync_Find_Results
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+
+/**
+ * Results for an EAS Find command request.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ */
+class Horde_ActiveSync_Find_Results
+{
+    /**
+     * @param int        $status       Top-level Find status.
+     * @param int        $storeStatus  Store-level status.
+     * @param int        $total        Total matching entries.
+     * @param array|null $rows         Result rows or null on error.
+     */
+    public function __construct(
+        public int $status,
+        public int $storeStatus,
+        public int $total,
+        public ?array $rows,
+    ) {}
+}

--- a/lib/Horde/ActiveSync/Imap/Adapter.php
+++ b/lib/Horde/ActiveSync/Imap/Adapter.php
@@ -604,13 +604,170 @@ class Horde_ActiveSync_Imap_Adapter
      *
      * @param array $query          The search query.
      * @param array $options        The search options.
-     * @param bool  $deepTraversal  Not currently supported.
+     * @param bool  $deepTraversal  If true, include sub-mailboxes of the target folder.
      *
      * @return array  An array of 'uniqueid', 'searchfolderid' hashes.
      */
     public function queryMailbox(array $query, array $options, bool $deepTraversal): array|int
     {
         return $this->_doQuery($query, $options, $deepTraversal);
+    }
+
+    /**
+     * Resolve a message long id (mailbox:uid) when the client uses a virtual
+     * folder id (e.g. iOS All Mailboxes "M&lt;uid&gt;" from Find search).
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param integer $uid  IMAP message UID.
+     *
+     * @return string|null  Long id or null if not found.
+     */
+    public function resolveLongIdForUid(int $uid): ?string
+    {
+        if ($uid <= 0) {
+            return null;
+        }
+
+        $imap_query = new Horde_Imap_Client_Search_Query();
+        $imap_query->ids(new Horde_Imap_Client_Ids([$uid], false));
+
+        $matches = [];
+        foreach ($this->getMailboxes() as $mailbox) {
+            try {
+                $search_res = $this->_getImapOb()->search(
+                    $mailbox['ob'],
+                    $imap_query,
+                    [
+                        'results' => [Horde_Imap_Client::SEARCH_RESULTS_MATCH],
+                    ]
+                );
+            } catch (Horde_Imap_Client_Exception $e) {
+                continue;
+            }
+
+            if ($search_res['count'] > 0) {
+                $matches[] = $mailbox['ob']->utf8;
+            }
+        }
+
+        if (!$matches) {
+            return null;
+        }
+
+        if (count($matches) > 1) {
+            $this->_logger->info(sprintf(
+                'UID %d exists in %d mailboxes; using %s for ItemOperations fetch.',
+                $uid,
+                count($matches),
+                $matches[0]
+            ));
+        }
+
+        return $matches[0] . ':' . $uid;
+    }
+
+    /**
+     * Perform a Find mailbox search.
+     *
+     * @deprecated Use queryMailbox() via getSearchResults() instead.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param array $query          Parsed Find query (freetext, class, serverid).
+     * @param bool  $deepTraversal  If true, include subfolders.
+     *
+     * @return array  Array of uniqueid/searchfolderid hashes.
+     */
+    public function queryFind(array $query, bool $deepTraversal): array
+    {
+        $imap_query = new Horde_Imap_Client_Search_Query();
+        $imap_query->charset('UTF-8', false);
+
+        if (!empty($query['freetext'])) {
+            $imap_query = Horde_ActiveSync_Find_Kql::toImapQuery($query['freetext']);
+        }
+
+        $mboxes = [];
+        if (!empty($query['serverid'])) {
+            $mboxes[] = new Horde_Imap_Client_Mailbox($query['serverid']);
+            if ($deepTraversal) {
+                $mboxes = array_merge($mboxes, $this->_getSubMailboxes($query['serverid']));
+            }
+        } else {
+            foreach ($this->getMailboxes() as $mailbox) {
+                $mboxes[] = $mailbox['ob'];
+            }
+        }
+
+        $results = [];
+        foreach ($mboxes as $mbox) {
+            try {
+                $search_res = $this->_getImapOb()->search(
+                    $mbox,
+                    $imap_query,
+                    [
+                        'results' => [
+                            Horde_Imap_Client::SEARCH_RESULTS_MATCH,
+                            Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+                        ],
+                        'sort' => [
+                            Horde_Imap_Client::SORT_REVERSE,
+                            Horde_Imap_Client::SORT_ARRIVAL,
+                        ],
+                    ]
+                );
+            } catch (Horde_Imap_Client_Exception $e) {
+                throw new Horde_ActiveSync_Exception($e);
+            }
+
+            if ($search_res['count'] == 0) {
+                continue;
+            }
+
+            foreach ($search_res['match']->ids as $id) {
+                $results[] = [
+                    'uniqueid' => $mbox->utf8 . ':' . $id,
+                    'searchfolderid' => $mbox->utf8,
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Return all sub-mailboxes for a given mailbox.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param string $mailbox  Parent mailbox name.
+     *
+     * @return Horde_Imap_Client_Mailbox[]
+     */
+    protected function _getSubMailboxes($mailbox)
+    {
+        $mboxes = [];
+        try {
+            $mbox_ob = new Horde_Imap_Client_Mailbox($mailbox);
+            $ns = $this->_getNamespace($mailbox);
+            $delimiter = $ns['delimiter'] ?? '.';
+            $list = $this->_getImapOb()->listMailboxes(
+                $mbox_ob->list_escape . $delimiter . '*',
+                Horde_Imap_Client::MBOX_ALL,
+                ['flat' => true]
+            );
+        } catch (Horde_Imap_Client_Exception $e) {
+            return $mboxes;
+        }
+
+        foreach ($list as $mbox) {
+            if ($mbox->utf8 !== $mailbox) {
+                $mboxes[] = $mbox;
+            }
+        }
+
+        return $mboxes;
     }
 
     /**
@@ -929,9 +1086,8 @@ class Horde_ActiveSync_Imap_Adapter
      *
      * @param array $query          The search query.
      * @param array $options        The search options (currently not used).
-     * @param bool  $deepTraversal  Not currently supported.
+     * @param bool  $deepTraversal  If true, include sub-mailboxes of the target folder.
      *
-     * @todo Implement $deepTraversal support.
      * @todo Implement $options support.
      *
      * @return array  Returns array containing an array of hashes:
@@ -967,6 +1123,12 @@ class Horde_ActiveSync_Imap_Adapter
                         break;
                     case 'serverid':
                         $mboxes[] = new Horde_Imap_Client_Mailbox($value);
+                        if ($deepTraversal) {
+                            $mboxes = array_merge(
+                                $mboxes,
+                                $this->_getSubMailboxes($value)
+                            );
+                        }
                         break;
                     case Horde_ActiveSync_Message_Mail::POOMMAIL_DATERECEIVED:
                         $op = $q['op'] ?? '';
@@ -980,7 +1142,9 @@ class Horde_ActiveSync_Imap_Adapter
                         $imap_query->dateSearch($value, $query_range);
                         break;
                     case Horde_ActiveSync_Request_Search::SEARCH_FREETEXT:
-                        $imap_query->text($value, false);
+                        $imap_query->andSearch([
+                            Horde_ActiveSync_Find_Kql::toImapQuery($value),
+                        ]);
                         break;
                     case 'subquery':
                         $imap_query->andSearch([$this->_buildSubQuery($value)]);
@@ -993,6 +1157,17 @@ class Horde_ActiveSync_Imap_Adapter
             foreach ($this->getMailboxes() as $mailbox) {
                 $mboxes[] = $mailbox['ob'];
             }
+        } else {
+            $seen = [];
+            $unique = [];
+            foreach ($mboxes as $mbox) {
+                $key = $mbox->utf8;
+                if (!isset($seen[$key])) {
+                    $seen[$key] = true;
+                    $unique[] = $mbox;
+                }
+            }
+            $mboxes = $unique;
         }
 
         $results = [];

--- a/lib/Horde/ActiveSync/Imap/Adapter.php
+++ b/lib/Horde/ActiveSync/Imap/Adapter.php
@@ -702,6 +702,13 @@ class Horde_ActiveSync_Imap_Adapter
 
         $results = [];
         foreach ($mboxes as $mbox) {
+            if ($this->_clientDisconnected()) {
+                $this->_logger->meta(
+                    'FIND/Search: Client disconnected during mailbox search.'
+                );
+                break;
+            }
+
             try {
                 $search_res = $this->_getImapOb()->search(
                     $mbox,
@@ -1172,6 +1179,13 @@ class Horde_ActiveSync_Imap_Adapter
 
         $results = [];
         foreach ($mboxes as $mbox) {
+            if ($this->_clientDisconnected()) {
+                $this->_logger->meta(
+                    'FIND/Search: Client disconnected during mailbox search.'
+                );
+                break;
+            }
+
             try {
                 $search_res = $this->_getImapOb()->search(
                     $mbox,
@@ -1305,5 +1319,17 @@ class Horde_ActiveSync_Imap_Adapter
         }
 
         return [];
+    }
+
+    /**
+     * Check whether the HTTP client has closed the connection.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @return boolean
+     */
+    protected function _clientDisconnected(): bool
+    {
+        return function_exists('connection_aborted') && connection_aborted();
     }
 }

--- a/lib/Horde/ActiveSync/Request/Base.php
+++ b/lib/Horde/ActiveSync/Request/Base.php
@@ -298,6 +298,16 @@ abstract class Horde_ActiveSync_Request_Base
     }
 
     /**
+     * Check whether the HTTP client has closed the connection.
+     *
+     * @return boolean
+     */
+    protected function _clientDisconnected(): bool
+    {
+        return function_exists('connection_aborted') && connection_aborted();
+    }
+
+    /**
      * Implementation method for handling request.
      *
      * @return string|boolean  Content-Type of results if not wbxml, or boolean.

--- a/lib/Horde/ActiveSync/Request/Find.php
+++ b/lib/Horde/ActiveSync/Request/Find.php
@@ -1,0 +1,549 @@
+<?php
+
+/**
+ * Horde_ActiveSync_Request_Find
+ *
+ * Handle EAS 16.0 Find command requests.
+ *
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @package   ActiveSync
+ * @internal
+ */
+class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
+{
+    public const FIND_FIND                    = 'Find:Find';
+    public const FIND_SEARCHID                = 'Find:SearchId';
+    public const FIND_EXECUTESEARCH           = 'Find:ExecuteSearch';
+    public const FIND_MAILBOXSEARCHCRITERION  = 'Find:MailBoxSearchCriterion';
+    public const FIND_GALSEARCHCRITERION      = 'Find:GALSearchCriterion';
+    public const FIND_QUERY                   = 'Find:Query';
+    public const FIND_FREETEXT                = 'Find:FreeText';
+    public const FIND_OPTIONS                 = 'Find:Options';
+    public const FIND_RANGE                   = 'Find:Range';
+    public const FIND_DEEPTRAVERSAL           = 'Find:DeepTraversal';
+    public const FIND_PICTURE                 = 'Find:Picture';
+    public const FIND_MAXSIZE                 = 'Find:MaxSize';
+    public const FIND_MAXPICTURES             = 'Find:MaxPictures';
+    public const FIND_STATUS                  = 'Find:Status';
+    public const FIND_RESPONSE                = 'Find:Response';
+    public const FIND_RESULT                  = 'Find:Result';
+    public const FIND_PROPERTIES              = 'Find:Properties';
+    public const FIND_TOTAL                   = 'Find:Total';
+    public const FIND_DISPLAYCC               = 'Find:DisplayCc';
+    public const FIND_DISPLAYBCC              = 'Find:DisplayBcc';
+    public const FIND_PREVIEW                 = 'Find:Preview';
+    public const FIND_HASATTACHMENTS          = 'Find:HasAttachments';
+
+    public const STATUS_SUCCESS               = 1;
+    public const STATUS_ERROR                 = 2;
+
+    public const STORE_STATUS_SUCCESS         = 1;
+    public const STORE_STATUS_SERVERERR       = 3;
+    public const STORE_STATUS_RANGEERR        = 12;
+
+    protected const MAX_RESULTS               = 100;
+
+    /**
+     * @var Horde_ActiveSync_Collections
+     */
+    protected $_collections;
+
+    /**
+     * Client FolderId from the Find request (for result encoding).
+     *
+     * @var string|null
+     */
+    protected $_findFolderUid;
+
+    /**
+     * Handle request.
+     *
+     * @return boolean
+     */
+    protected function _handle()
+    {
+        $this->_logger->meta('Handling FIND command.');
+        $this->_collections = $this->_activeSync->getCollectionsObject();
+
+        if (!$this->_decoder->getElementStartTag(self::FIND_FIND)) {
+            throw new Horde_ActiveSync_Exception_InvalidRequest('Missing required Find element.');
+        }
+
+        $searchId = null;
+        $type = null;
+        $query = [];
+        $options = [];
+        $range = null;
+        $deepTraversal = false;
+        $bodyprefs = [];
+        $mime = Horde_ActiveSync::MIME_SUPPORT_NONE;
+
+        if ($this->_decoder->getElementStartTag(self::FIND_SEARCHID)) {
+            $searchId = $this->_decoder->getElementContent();
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if (!$this->_decoder->getElementStartTag(self::FIND_EXECUTESEARCH)) {
+            throw new Horde_ActiveSync_Exception_InvalidRequest('Missing required ExecuteSearch element.');
+        }
+
+        if ($this->_decoder->getElementStartTag(self::FIND_MAILBOXSEARCHCRITERION)) {
+            $type = 'mailbox';
+            $parsed = $this->_parseMailboxCriterion();
+            if ($parsed === false) {
+                return false;
+            }
+            $query = $parsed['query'];
+            if (!empty($parsed['options'])) {
+                $options = array_merge($options, $parsed['options']);
+            }
+            if (!empty($options['range'])) {
+                $range = $options['range'];
+            }
+            if (!empty($options['deeptraversal'])) {
+                $deepTraversal = true;
+            }
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if ($this->_decoder->getElementStartTag(self::FIND_GALSEARCHCRITERION)) {
+            $type = 'gal';
+            $query = ['text' => $this->_decoder->getElementContent()];
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if (!$type) {
+            throw new Horde_ActiveSync_Exception_InvalidRequest('Missing search criterion.');
+        }
+
+        if (!$this->_decoder->getElementEndTag()) { // ExecuteSearch
+            return false;
+        }
+
+        if ($this->_decoder->getElementStartTag(self::FIND_OPTIONS)) {
+            while (1) {
+                if ($this->_decoder->getElementStartTag(self::FIND_RANGE)) {
+                    $range = $this->_decoder->getElementContent();
+                    if (!$this->_decoder->getElementEndTag()) {
+                        return false;
+                    }
+                }
+                if ($this->_decoder->getElementStartTag(self::FIND_DEEPTRAVERSAL)) {
+                    if (!($deepTraversal = $this->_decoder->getElementContent())) {
+                        $deepTraversal = true;
+                    } elseif (!$this->_decoder->getElementEndTag()) {
+                        return false;
+                    }
+                }
+                if ($this->_decoder->getElementStartTag(Horde_ActiveSync::AIRSYNCBASE_BODYPREFERENCE)) {
+                    $this->_bodyPrefs($bodyprefs);
+                }
+                if ($this->_decoder->getElementStartTag(Horde_ActiveSync::SYNC_MIMESUPPORT)) {
+                    $this->_mimeSupport($bodyprefs);
+                }
+                if ($this->_decoder->getElementStartTag(self::FIND_PICTURE)) {
+                    $options[self::FIND_PICTURE] = true;
+                    if ($this->_decoder->getElementStartTag(self::FIND_MAXSIZE)) {
+                        $options[self::FIND_MAXSIZE] = $this->_decoder->getElementContent();
+                        if (!$this->_decoder->getElementEndTag()) {
+                            return false;
+                        }
+                    }
+                    if ($this->_decoder->getElementStartTag(self::FIND_MAXPICTURES)) {
+                        $options[self::FIND_MAXPICTURES] = $this->_decoder->getElementContent();
+                        if (!$this->_decoder->getElementEndTag()) {
+                            return false;
+                        }
+                    }
+                    if (!$this->_decoder->getElementEndTag()) {
+                        return false;
+                    }
+                }
+
+                $e = $this->_decoder->peek();
+                if ($e[Horde_ActiveSync_Wbxml::EN_TYPE] == Horde_ActiveSync_Wbxml::EN_TYPE_ENDTAG) {
+                    $this->_decoder->getElementEndTag();
+                    break;
+                }
+            }
+        }
+
+        if (!$this->_decoder->getElementEndTag()) { // Find
+            return false;
+        }
+
+        $this->_findFolderUid = $query['collectionid'] ?? null;
+        $this->_logger->info(sprintf(
+            'Find criteria: type=%s searchId=%s folderUid=%s serverid=%s range=%s deepTraversal=%s freetext_len=%d',
+            $type,
+            $searchId ?? '',
+            $this->_findFolderUid ?? '',
+            $query['serverid'] ?? '',
+            $range ?? '',
+            $deepTraversal ? 'yes' : 'no',
+            isset($query['freetext']) ? strlen($query['freetext']) : 0
+        ));
+        if (!empty($query['freetext'])) {
+            $this->_logger->info('Find FreeText: ' . $query['freetext']);
+        } elseif (!empty($query['text'])) {
+            $this->_logger->info('Find GAL query: ' . $query['text']);
+        }
+
+        $status = self::STATUS_SUCCESS;
+        $storeStatus = self::STORE_STATUS_SUCCESS;
+        $start = 0;
+        $limit = self::MAX_RESULTS;
+
+        if ($range !== null) {
+            if (preg_match('/^(\d+)-(\d+)$/', $range, $matches)) {
+                $start = (int) $matches[1];
+                $end = (int) $matches[2];
+                if ($end < $start) {
+                    $storeStatus = self::STORE_STATUS_RANGEERR;
+                } else {
+                    $limit = $end - $start + 1;
+                    // iOS sends 0-100 (101 slots); cap to server maximum.
+                    if ($limit > self::MAX_RESULTS) {
+                        $limit = self::MAX_RESULTS;
+                    }
+                }
+            } else {
+                $storeStatus = self::STORE_STATUS_RANGEERR;
+            }
+        }
+
+        $results = null;
+        if ($storeStatus === self::STORE_STATUS_SUCCESS && $type) {
+            $params = new Horde_ActiveSync_Find_Params(
+                type: $type,
+                searchId: $searchId,
+                query: $query,
+                options: $options,
+                start: $start,
+                limit: $limit,
+                deepTraversal: $deepTraversal,
+            );
+
+            $results = $this->_driver->getFindResults(
+                $params,
+                empty($bodyprefs['bodyprefs']) ? [] : $bodyprefs['bodyprefs'],
+                $mime
+            );
+
+            if ($results->rows === null) {
+                $storeStatus = self::STORE_STATUS_SERVERERR;
+            }
+        }
+
+        $this->_encoder->startWBXML();
+        $this->_encoder->startTag(self::FIND_FIND);
+        $this->_encoder->startTag(self::FIND_STATUS);
+        $this->_encoder->content($status);
+        $this->_encoder->endTag();
+
+        if ($status === self::STATUS_SUCCESS) {
+            $this->_encoder->startTag(self::FIND_RESPONSE);
+            $this->_encoder->startTag(Horde_ActiveSync_Request_ItemOperations::ITEMOPERATIONS_STORE);
+            $this->_encoder->content('Mailbox');
+            $this->_encoder->endTag();
+
+            $this->_encoder->startTag(self::FIND_STATUS);
+            $this->_encoder->content($storeStatus);
+            $this->_encoder->endTag();
+
+            if ($storeStatus === self::STORE_STATUS_SUCCESS && $results) {
+                if ($results->rows) {
+                    $bodyPrefs = empty($bodyprefs['bodyprefs']) ? [] : $bodyprefs['bodyprefs'];
+                    if (empty($bodyPrefs['preview'])) {
+                        $bodyPrefs['preview'] = 255;
+                    }
+                    foreach ($results->rows as $row) {
+                        $this->_encodeResult($row, $type, $bodyPrefs, $mime);
+                    }
+                }
+
+                $returned = $results->rows ? count($results->rows) : 0;
+                $searchRange = $returned
+                    ? $start . '-' . ($start + $returned - 1)
+                    : $start . '-' . $start;
+                $this->_encoder->startTag(self::FIND_RANGE);
+                $this->_encoder->content($searchRange);
+                $this->_encoder->endTag();
+
+                $this->_encoder->startTag(self::FIND_TOTAL);
+                $this->_encoder->content($results->total);
+                $this->_encoder->endTag();
+            }
+
+            $this->_encoder->endTag(); // Response
+        }
+
+        $this->_encoder->endTag(); // Find
+
+        return true;
+    }
+
+    /**
+     * Parse MailBoxSearchCriterion.
+     *
+     * @return array
+     */
+    protected function _parseMailboxCriterion()
+    {
+        $query = [];
+        $options = [];
+
+        if (!$this->_decoder->getElementStartTag(self::FIND_QUERY)) {
+            throw new Horde_ActiveSync_Exception_InvalidRequest('Missing required Query element.');
+        }
+
+        if ($this->_decoder->getElementStartTag(Horde_ActiveSync::SYNC_FOLDERTYPE)) {
+            $query['class'] = $this->_decoder->getElementContent();
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if ($this->_decoder->getElementStartTag(Horde_ActiveSync::SYNC_FOLDERID)) {
+            $folderUid = $this->_decoder->getElementContent();
+            try {
+                $query['collectionid'] = $folderUid;
+                $query['serverid'] = $this->_collections->getBackendIdForFolderUid($folderUid);
+            } catch (Horde_ActiveSync_Exception_FolderGone $e) {
+                $this->_logger->err($e->getMessage());
+            }
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if ($this->_decoder->getElementStartTag(self::FIND_FREETEXT)) {
+            $query['freetext'] = $this->_decoder->getElementContent();
+            if (!$this->_decoder->getElementEndTag()) {
+                return false;
+            }
+        }
+
+        if (!$this->_decoder->getElementEndTag()) { // Query
+            return false;
+        }
+
+        if ($this->_decoder->getElementStartTag(self::FIND_OPTIONS)) {
+            $options = $this->_parseOptions();
+            if ($options === false) {
+                return false;
+            }
+        }
+
+        return ['query' => $query, 'options' => $options];
+    }
+
+    /**
+     * Parse an Options block.
+     *
+     * @return array
+     */
+    protected function _parseOptions()
+    {
+        $options = [];
+        while (1) {
+            if ($this->_decoder->getElementStartTag(self::FIND_RANGE)) {
+                $options['range'] = $this->_decoder->getElementContent();
+                if (!$this->_decoder->getElementEndTag()) {
+                    return false;
+                }
+            }
+            if ($this->_decoder->getElementStartTag(self::FIND_DEEPTRAVERSAL)) {
+                $options['deeptraversal'] = true;
+                if ($this->_decoder->getElementContent() !== false
+                    && !$this->_decoder->getElementEndTag()) {
+                    return false;
+                }
+            }
+            if ($this->_decoder->getElementStartTag(self::FIND_PICTURE)) {
+                $options[self::FIND_PICTURE] = true;
+                if ($this->_decoder->getElementStartTag(self::FIND_MAXSIZE)) {
+                    $options[self::FIND_MAXSIZE] = $this->_decoder->getElementContent();
+                    $this->_decoder->getElementEndTag();
+                }
+                if ($this->_decoder->getElementStartTag(self::FIND_MAXPICTURES)) {
+                    $options[self::FIND_MAXPICTURES] = $this->_decoder->getElementContent();
+                    $this->_decoder->getElementEndTag();
+                }
+                $this->_decoder->getElementEndTag();
+            }
+
+            $e = $this->_decoder->peek();
+            if ($e[Horde_ActiveSync_Wbxml::EN_TYPE] == Horde_ActiveSync_Wbxml::EN_TYPE_ENDTAG) {
+                $this->_decoder->getElementEndTag();
+                break;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Encode a single Find result.
+     *
+     * @param array       $row        Search hit from getSearchResults().
+     * @param string|null $type       Search type.
+     * @param array       $bodyprefs  Body preference options.
+     * @param integer     $mime       MIME support flag.
+     */
+    protected function _encodeResult(array $row, $type, array $bodyprefs, $mime)
+    {
+        $this->_encoder->startTag(self::FIND_RESULT);
+
+        if ($type === 'mailbox') {
+            $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
+            $this->_encoder->content(Horde_ActiveSync::CLASS_EMAIL);
+            $this->_encoder->endTag();
+
+            [, $uid] = explode(':', $row['uniqueid'], 2);
+            $this->_encoder->startTag(Horde_ActiveSync::SYNC_SERVERENTRYID);
+            $this->_encoder->content($uid);
+            $this->_encoder->endTag();
+
+            $folderUid = $this->_findFolderUid
+                ?? $this->_collections->getFolderUidForBackendId($row['searchfolderid']);
+            if (empty($folderUid)) {
+                $this->_logger->err(sprintf(
+                    'Find: no client FolderId for mailbox %s (UID in %s).',
+                    $row['searchfolderid'],
+                    $row['uniqueid']
+                ));
+            }
+            $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERID);
+            $this->_encoder->content($folderUid ?: '');
+            $this->_encoder->endTag();
+
+            $this->_encoder->startTag(self::FIND_PROPERTIES);
+            $msg = $this->_driver->itemOperationsFetchMailbox(
+                $row['uniqueid'],
+                $bodyprefs,
+                $mime
+            );
+            $this->_encodeFindMailProperties($msg);
+            $this->_encoder->endTag(); // Properties
+        } elseif ($type === 'gal') {
+            $this->_encoder->startTag(self::FIND_PROPERTIES);
+            foreach ($row as $tag => $value) {
+                if ($value === '' || $tag === 'class') {
+                    continue;
+                }
+                $this->_encoder->startTag($tag);
+                $this->_encoder->content($value);
+                $this->_encoder->endTag();
+            }
+            $this->_encoder->endTag();
+        }
+
+        $this->_encoder->endTag(); // Result
+    }
+
+    /**
+     * Encode the mail properties required for a Find response.
+     *
+     * @param Horde_ActiveSync_Message_Mail $msg  The message object.
+     */
+    protected function _encodeFindMailProperties(Horde_ActiveSync_Message_Mail $msg)
+    {
+        $this->_encodeFindElement(
+            Horde_ActiveSync_Message_Mail::POOMMAIL_SUBJECT,
+            $msg->subject
+        );
+        if ($msg->datereceived instanceof Horde_Date) {
+            $this->_encodeFindElement(
+                Horde_ActiveSync_Message_Mail::POOMMAIL_DATERECEIVED,
+                $msg->datereceived->setTimezone('UTC')->format('Y-m-d\TH:i:s.000\Z')
+            );
+        }
+        $this->_encodeFindElement(
+            Horde_ActiveSync_Message_Mail::POOMMAIL_DISPLAYTO,
+            $msg->displayto
+        );
+        $this->_encodeFindElement(
+            Horde_ActiveSync_Message_Mail::POOMMAIL_FROM,
+            $msg->from
+        );
+        $this->_encodeFindElement(
+            Horde_ActiveSync_Message_Mail::POOMMAIL_IMPORTANCE,
+            (string) ($msg->importance ?? 1)
+        );
+        $this->_encodeFindElement(
+            Horde_ActiveSync_Message_Mail::POOMMAIL_READ,
+            $msg->read ? '1' : '0'
+        );
+        if (isset($msg->isdraft)) {
+            $this->_encodeFindElement(
+                Horde_ActiveSync_Message_Mail::POOMMAIL2_ISDRAFT,
+                $msg->isdraft ? '1' : '0'
+            );
+        }
+
+        $this->_encodeFindElement(self::FIND_PREVIEW, $this->_extractPreview($msg));
+
+        $hasAttachments = !empty($msg->airsyncbaseattachments);
+        $this->_encodeFindElement(
+            self::FIND_HASATTACHMENTS,
+            $hasAttachments ? '1' : '0'
+        );
+        $this->_encodeFindElement(self::FIND_DISPLAYCC, $msg->cc ?? '');
+        $this->_encodeFindElement(self::FIND_DISPLAYBCC, $msg->bcc ?? '');
+    }
+
+    /**
+     * Build a Find preview string from message body data.
+     *
+     * @param Horde_ActiveSync_Message_Mail $msg  The message object.
+     *
+     * @return string
+     */
+    protected function _extractPreview(Horde_ActiveSync_Message_Mail $msg): string
+    {
+        if (empty($msg->airsyncbasebody)) {
+            return '';
+        }
+
+        if (!empty($msg->airsyncbasebody->preview)) {
+            return (string) $msg->airsyncbasebody->preview;
+        }
+
+        if (empty($msg->airsyncbasebody->data)) {
+            return '';
+        }
+
+        $data = $msg->airsyncbasebody->data;
+        if (is_resource($data)) {
+            $data = stream_get_contents($data, 255);
+            if ($data === false) {
+                return '';
+            }
+        }
+
+        return Horde_String::substr((string) $data, 0, 255);
+    }
+
+    /**
+     * @param string $tag    WBXML tag name.
+     * @param string $value  Element content.
+     */
+    protected function _encodeFindElement($tag, $value)
+    {
+        if ($value === '' || $value === null) {
+            return;
+        }
+        $this->_encoder->startTag($tag);
+        $this->_encoder->content($value);
+        $this->_encoder->endTag();
+    }
+}

--- a/lib/Horde/ActiveSync/Request/Find.php
+++ b/lib/Horde/ActiveSync/Request/Find.php
@@ -243,6 +243,13 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
             }
         }
 
+        if ($this->_clientDisconnected()) {
+            $this->_logger->meta(
+                'FIND: Client disconnected, skipping response encoding.'
+            );
+            return true;
+        }
+
         $this->_encoder->startWBXML();
         $this->_encoder->startTag(self::FIND_FIND);
         $this->_encoder->startTag(self::FIND_STATUS);
@@ -260,17 +267,23 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
             $this->_encoder->endTag();
 
             if ($storeStatus === self::STORE_STATUS_SUCCESS && $results) {
+                $returned = 0;
                 if ($results->rows) {
                     $bodyPrefs = empty($bodyprefs['bodyprefs']) ? [] : $bodyprefs['bodyprefs'];
                     if (empty($bodyPrefs['preview'])) {
                         $bodyPrefs['preview'] = 255;
                     }
                     foreach ($results->rows as $row) {
+                        if ($this->_clientDisconnected()) {
+                            $this->_logger->meta(
+                                'FIND: Client disconnected during result encoding.'
+                            );
+                            break;
+                        }
                         $this->_encodeResult($row, $type, $bodyPrefs, $mime);
+                        $returned++;
                     }
                 }
-
-                $returned = $results->rows ? count($results->rows) : 0;
                 $searchRange = $returned
                     ? $start . '-' . ($start + $returned - 1)
                     : $start . '-' . $start;

--- a/lib/Horde/ActiveSync/Request/ItemOperations.php
+++ b/lib/Horde/ActiveSync/Request/ItemOperations.php
@@ -246,14 +246,36 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
                                     $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
                                     $this->_encoder->content('Email');
                                     $this->_encoder->endTag();
-                                    $mailbox = $collections->getBackendIdForFolderUid($value['folderid']);
-                                    $msg = $this->_driver->fetch(
-                                        $mailbox,
-                                        $value['serverentryid'],
-                                        [
-                                            'bodyprefs' => $value['bodyprefs'],
-                                            'mimesupport' => $mimesupport]
-                                    );
+
+                                    $longid = $this->_resolveFetchLongId($value);
+                                    if ($longid) {
+                                        $msg = $this->_driver->itemOperationsFetchMailbox(
+                                            $longid,
+                                            $value['bodyprefs'],
+                                            $mimesupport
+                                        );
+                                    } else {
+                                        try {
+                                            $mailbox = $collections->getBackendIdForFolderUid($value['folderid']);
+                                        } catch (Horde_ActiveSync_Exception_FolderGone $e) {
+                                            $this->_logger->err(sprintf(
+                                                'ItemOperations fetch: folder %s not in cache for UID %s.',
+                                                $value['folderid'],
+                                                $value['serverentryid']
+                                            ));
+                                            $this->_statusCode = self::STATUS_SERVERERR;
+                                            $mailbox = null;
+                                        }
+                                        if ($this->_statusCode == self::STATUS_SUCCESS) {
+                                            $msg = $this->_driver->fetch(
+                                                $mailbox,
+                                                $value['serverentryid'],
+                                                [
+                                                    'bodyprefs' => $value['bodyprefs'],
+                                                    'mimesupport' => $mimesupport]
+                                            );
+                                        }
+                                    }
                                 }
                             }
                             if ($this->_statusCode == self::STATUS_SUCCESS) {
@@ -352,6 +374,45 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
      *
      * @return integer  The size of the data.
      */
+    /**
+     * Resolve mailbox:uid for ItemOperations when the client uses a virtual
+     * folder id from unified Find search (e.g. iOS All Mailboxes "M&lt;uid&gt;").
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param array $value  Parsed ItemOperations fetch request.
+     *
+     * @return string|null  Long id suitable for itemOperationsFetchMailbox().
+     */
+    protected function _resolveFetchLongId(array $value): ?string
+    {
+        if (!isset($value['serverentryid'])
+            || !method_exists($this->_driver, 'resolveLongIdForUid')) {
+            return null;
+        }
+
+        $folderid = $value['folderid'] ?? '';
+        $needsResolve = ($folderid !== '' && $folderid[0] === 'M');
+
+        if (!$needsResolve) {
+            $collections = $this->_activeSync->getCollectionsObject();
+            try {
+                $collections->getBackendIdForFolderUid($folderid);
+                return null;
+            } catch (Horde_ActiveSync_Exception_FolderGone $e) {
+                $needsResolve = true;
+            }
+        }
+
+        if (!$needsResolve) {
+            return null;
+        }
+
+        $uid = (int) $value['serverentryid'];
+
+        return $uid > 0 ? $this->_driver->resolveLongIdForUid($uid) : null;
+    }
+
     protected function _getDataSize($data)
     {
         if (is_resource($data)) {

--- a/lib/Horde/ActiveSync/Wbxml.php
+++ b/lib/Horde/ActiveSync/Wbxml.php
@@ -812,6 +812,34 @@ class Horde_ActiveSync_Wbxml
                 0x18 => 'RemoveRightsManagementDistribution',
             ],
 
+            /* Find (16.0) — token order per MS-ASWBXML code page 25 / Z-Push
+             * @author Torben Dannhauer <torben@dannhauer.de>
+             */
+            0x19 => [
+                0x05 => 'Find',
+                0x06 => 'SearchId',
+                0x07 => 'ExecuteSearch',
+                0x08 => 'MailBoxSearchCriterion',
+                0x09 => 'Query',
+                0x0A => 'Status',
+                0x0B => 'FreeText',
+                0x0C => 'Options',
+                0x0D => 'Range',
+                0x0E => 'DeepTraversal',
+                0x11 => 'Response',
+                0x12 => 'Result',
+                0x13 => 'Properties',
+                0x14 => 'Preview',
+                0x15 => 'HasAttachments',
+                0x16 => 'Total',
+                0x17 => 'DisplayCc',
+                0x18 => 'DisplayBcc',
+                0x19 => 'GALSearchCriterion',
+                0x20 => 'MaxPictures',
+                0x21 => 'MaxSize',
+                0x22 => 'Picture',
+            ],
+
             // Windows Live
             0xFE => [
                 0x05 => 'Annotations',
@@ -847,6 +875,8 @@ class Horde_ActiveSync_Wbxml
             0x16 => 'POOMMAIL2',
             0x17 => 'Notes',
             0x18 => 'RightsManagement',
+            // EAS 16.0
+            0x19 => 'Find',
             // Hotmail/Outlook.com WBXML extension.
             0xFE => 'WindowsLive',
         ],

--- a/test/Horde/ActiveSync/FindKqlTest.php
+++ b/test/Horde/ActiveSync/FindKqlTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Unit tests for Horde_ActiveSync_Find_Kql.
+ *
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @package   ActiveSync
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class Horde_ActiveSync_FindKqlTest extends TestCase
+{
+    public function testPlainTextQuery()
+    {
+        $q = Horde_ActiveSync_Find_Kql::toImapQuery('meeting notes');
+        $this->assertInstanceOf('Horde_Imap_Client_Search_Query', $q);
+    }
+
+    public function testFromToken()
+    {
+        $q = Horde_ActiveSync_Find_Kql::toImapQuery('from:john@example.com');
+        $this->assertInstanceOf('Horde_Imap_Client_Search_Query', $q);
+    }
+
+    public function testSubjectToken()
+    {
+        $q = Horde_ActiveSync_Find_Kql::toImapQuery('subject:"quarterly report"');
+        $this->assertInstanceOf('Horde_Imap_Client_Search_Query', $q);
+    }
+
+    public function testIphoneOrExpansionQuery()
+    {
+        $kql = 'to:"Stoewer" OR cc:"Stoewer" OR from:"Stoewer" OR subject:"Stoewer" OR "Stoewer" OR "Stoewer"';
+        $q = Horde_ActiveSync_Find_Kql::toImapQuery($kql);
+        $this->assertInstanceOf('Horde_Imap_Client_Search_Query', $q);
+    }
+}

--- a/test/Horde/ActiveSync/FindQueryMapperTest.php
+++ b/test/Horde/ActiveSync/FindQueryMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Unit tests for Horde_ActiveSync_Find_QueryMapper.
+ *
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @license   http://www.horde.org/licenses/gpl GPLv2
+ * @copyright 2026 Horde LLC (http://www.horde.org)
+ * @package   ActiveSync
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class Horde_ActiveSync_FindQueryMapperTest extends TestCase
+{
+    public function testMailboxQueryMapsToSearchAndCriterion()
+    {
+        $find = new Horde_ActiveSync_Find_Params(
+            type: 'mailbox',
+            searchId: '00000000-0000-0000-0000-000000000001',
+            query: [
+                'class' => 'Email',
+                'collectionid' => 'F0cfc112a',
+                'serverid' => 'INBOX',
+                'freetext' => 'from:alice@example.com subject:report',
+            ],
+            options: [],
+            start: 0,
+            limit: 100,
+            deepTraversal: true,
+        );
+
+        $search = Horde_ActiveSync_Find_QueryMapper::toSearchParams($find);
+
+        $this->assertSame('mailbox', $search->type);
+        $this->assertTrue($search->deepTraversal);
+        $this->assertSame(0, $search->start);
+        $this->assertSame(100, $search->limit);
+        $this->assertCount(1, $search->query);
+        $this->assertSame(
+            Horde_ActiveSync_Request_Search::SEARCH_AND,
+            $search->query[0]['op']
+        );
+        $this->assertSame('Email', $search->query[0]['value']['FolderType']);
+        $this->assertSame('INBOX', $search->query[0]['value']['serverid']);
+        $this->assertSame(
+            'from:alice@example.com subject:report',
+            $search->query[0]['value'][Horde_ActiveSync_Request_Search::SEARCH_FREETEXT]
+        );
+    }
+
+    public function testGalQueryMapsToSearchGalFormat()
+    {
+        $find = new Horde_ActiveSync_Find_Params(
+            type: 'gal',
+            searchId: '00000000-0000-0000-0000-000000000002',
+            query: ['text' => 'Michael'],
+            options: [],
+            start: 0,
+            limit: 50,
+            deepTraversal: false,
+        );
+
+        $search = Horde_ActiveSync_Find_QueryMapper::toSearchParams($find);
+
+        $this->assertSame('gal', $search->type);
+        $this->assertSame(['Michael'], $search->query);
+        $this->assertFalse($search->deepTraversal);
+    }
+}

--- a/test/Horde/ActiveSync/ServerTest.php
+++ b/test/Horde/ActiveSync/ServerTest.php
@@ -9,8 +9,8 @@
  */
 
 namespace Horde\ActiveSync;
-
 use PHPUnit\Framework\Attributes\CoversNothing;
+
 use Horde_Test_Case as TestCase;
 use Horde\ActiveSync\Factory\TestServer;
 use Horde_ActiveSync;
@@ -36,7 +36,7 @@ class ServerTest extends TestCase
     public function testSupportedCommands()
     {
         $factory = new TestServer();
-        $this->assertEquals('Sync,SendMail,SmartForward,SmartReply,GetAttachment,GetHierarchy,CreateCollection,DeleteCollection,MoveCollection,FolderSync,FolderCreate,FolderDelete,FolderUpdate,MoveItems,GetItemEstimate,MeetingResponse,Search,Settings,Ping,ItemOperations,Provision,ResolveRecipients,ValidateCert', $factory->server->getSupportedCommands());
+        $this->assertEquals('Sync,SendMail,SmartForward,SmartReply,GetAttachment,GetHierarchy,CreateCollection,DeleteCollection,MoveCollection,FolderSync,FolderCreate,FolderDelete,FolderUpdate,MoveItems,GetItemEstimate,MeetingResponse,Search,Settings,Ping,ItemOperations,Provision,ResolveRecipients,ValidateCert,Find', $factory->server->getSupportedCommands());
         $factory->server->setSupportedVersion(Horde_ActiveSync::VERSION_TWOFIVE);
         $this->assertEquals('Sync,SendMail,SmartForward,SmartReply,GetAttachment,GetHierarchy,CreateCollection,DeleteCollection,MoveCollection,FolderSync,FolderCreate,FolderDelete,FolderUpdate,MoveItems,GetItemEstimate,MeetingResponse,ResolveRecipients,ValidateCert,Provision,Search,Ping', $factory->server->getSupportedCommands());
     }


### PR DESCRIPTION
# Add EAS 16.0 Find command support

## Summary

Implements the Exchange ActiveSync **Find** command (protocol version 16.0) so modern clients— notably iOS Mail— can search mailbox content via **KQL** instead of relying on the legacy Search command.

Find is exposed as a thin protocol layer on top of the existing IMAP search backend used by Search. A companion PR for `horde/core` wires `getFindResults()` to IMP; this PR contains all `horde/activesync` changes.

## Motivation

iOS 16+ sends `Cmd=Find` for unified mailbox search. Horde previously had no Find handler, which resulted in HTTP 400 (`Find not supported`). This change adds full request parsing, WBXML encoding, IMAP query execution, and the ItemOperations follow-up needed to open search hits on iPhone.

Tested on iPhone (EAS 16.0): global search, subfolder hits, result list, and opening messages from search results.

## Changes

### Protocol and request handling

- Add `Horde_ActiveSync_Request_Find` — parses Find requests (`SearchId`, `ExecuteSearch`, `MailBoxSearchCriterion`, `GALSearchCriterion`, `Query`, `FreeText`, `Options`, `Range`, `DeepTraversal`)
- Register Find WBXML code page `0x19` with token order per MS-ASWBXML / Z-Push (code page 25)
- Advertise `Find` in supported commands for `VERSION_SIXTEEN` in `Horde_ActiveSync.php`
- Encode Find responses (`Status`, `Response`, `Result`, mail properties, `Preview`, `HasAttachments`, `Range`, `Total`)
- Cap iPhone `Range` `0-100` to server maximum (100) instead of returning status 12

### Find support types

| File | Role |
|------|------|
| `lib/Horde/ActiveSync/Find/Params.php` | Find request DTO |
| `lib/Horde/ActiveSync/Find/Results.php` | Find results DTO |
| `lib/Horde/ActiveSync/Find/QueryMapper.php` | Maps Find params → Search params |
| `lib/Horde/ActiveSync/Find/Kql.php` | KQL → `Horde_Imap_Client_Search_Query` (incl. `OR` for iOS patterns) |

### IMAP search backend

- Extend `Horde_ActiveSync_Imap_Adapter::_doQuery()` for Find/Search-shared mailbox queries
- Add `_getSubMailboxes()` for `DeepTraversal` (search folder + subfolders)
- When no folder is specified, search all account mailboxes (global search)
- Add `resolveLongIdForUid()` — locate `mailbox:uid` when client uses a virtual folder id

### ItemOperations (iOS follow-up)

When the user taps a Find result, iOS sends ItemOperations Fetch with a virtual **All Mailboxes** folder id (`M<uid>`), which is not in the device folder cache. `ItemOperations.php` now falls back to UID-based long-id resolution instead of failing with “Folder not found in cache”.

### Driver interface

- Add abstract `getFindResults()` to `Horde_ActiveSync_Driver_Base`
- Stub implementation in `Horde_ActiveSync_Driver_Mock`

### Preview encoding fix

Find result encoding reads body preview from stream resources via `_extractPreview()` and requests a default `preview: 255` bodypref when fetching hit metadata.

## Files in this PR

**New**

- `lib/Horde/ActiveSync/Request/Find.php`
- `lib/Horde/ActiveSync/Find/Params.php`
- `lib/Horde/ActiveSync/Find/Results.php`
- `lib/Horde/ActiveSync/Find/QueryMapper.php`
- `lib/Horde/ActiveSync/Find/Kql.php`
- `test/Horde/ActiveSync/FindKqlTest.php`
- `test/Horde/ActiveSync/FindQueryMapperTest.php`

**Modified**

- `lib/Horde/ActiveSync.php`
- `lib/Horde/ActiveSync/Wbxml.php`
- `lib/Horde/ActiveSync/Driver/Base.php`
- `lib/Horde/ActiveSync/Driver/Mock.php`
- `lib/Horde/ActiveSync/Imap/Adapter.php`
- `lib/Horde/ActiveSync/Request/Base.php`
- `lib/Horde/ActiveSync/Request/ItemOperations.php`
- `test/Horde/ActiveSync/ServerTest.php`

## Architecture

```
Find request
  → Horde_ActiveSync_Request_Find (parse + encode)
  → driver.getFindResults()          [implemented in horde/core PR]
      → QueryMapper → getSearchResults()
      → Imap Adapter _doQuery() → IMAP SEARCH per mailbox
  → encode Results (properties + Preview)

Tap result on iOS
  → ItemOperations Fetch (virtual M<uid> folder)
  → resolveLongIdForUid() → itemOperationsFetchMailbox(mailbox:uid)
```

## Test plan

- [ ] Run unit tests:
  ```bash
  phpunit test/Horde/ActiveSync/FindKqlTest.php
  phpunit test/Horde/ActiveSync/FindQueryMapperTest.php
  phpunit test/Horde/ActiveSync/ServerTest.php
  ```
- [x] With `horde/core` Find wiring deployed, test on EAS 16.0 client (iPhone):
  - [x] Global search returns hits from INBOX and subfolders
  - [x] Tapping a result opens the full message (no ItemOperations 500)
  - [x] Search with visible results includes `Preview`, `Range`, and `Total` in device log
- [ ] Verify Find is **not** advertised for protocol versions below 16.0

## Follow-up

Requires a separate **`horde/core`** PR adding `Horde_Core_ActiveSync_Driver::getFindResults()` and `resolveLongIdForUid()` delegation to the IMAP adapter. Without that PR, Find requests will fail at the driver layer.

## Author

Torben Dannhauer <torben@dannhauer.de>

requires https://github.com/horde/Core/pull/137