### PR TITLE
fix(activesync): skip missing messages in Find results

### DIFF
--- a/lib/Horde/ActiveSync/Request/Find.php
+++ b/lib/Horde/ActiveSync/Request/Find.php
@@ -280,8 +280,9 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
                             );
                             break;
                         }
-                        $this->_encodeResult($row, $type, $bodyPrefs, $mime);
-                        $returned++;
+                        if ($this->_encodeResult($row, $type, $bodyPrefs, $mime)) {
+                            $returned++;
+                        }
                     }
                 }
                 $searchRange = $returned
@@ -411,9 +412,28 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
      * @param string|null $type       Search type.
      * @param array       $bodyprefs  Body preference options.
      * @param integer     $mime       MIME support flag.
+     *
+     * @return boolean  True if the result was encoded.
      */
     protected function _encodeResult(array $row, $type, array $bodyprefs, $mime)
     {
+        if ($type === 'mailbox') {
+            try {
+                $msg = $this->_driver->itemOperationsFetchMailbox(
+                    $row['uniqueid'],
+                    $bodyprefs,
+                    $mime
+                );
+            } catch (Horde_Exception_NotFound $e) {
+                $this->_logger->info(sprintf(
+                    'Find: message %s no longer available (%s), skipping result.',
+                    $row['uniqueid'],
+                    $e->getMessage()
+                ));
+                return false;
+            }
+        }
+
         $this->_encoder->startTag(self::FIND_RESULT);
 
         if ($type === 'mailbox') {
@@ -440,11 +460,6 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
             $this->_encoder->endTag();
 
             $this->_encoder->startTag(self::FIND_PROPERTIES);
-            $msg = $this->_driver->itemOperationsFetchMailbox(
-                $row['uniqueid'],
-                $bodyprefs,
-                $mime
-            );
             $this->_encodeFindMailProperties($msg);
             $this->_encoder->endTag(); // Properties
         } elseif ($type === 'gal') {
@@ -461,6 +476,8 @@ class Horde_ActiveSync_Request_Find extends Horde_ActiveSync_Request_SyncBase
         }
 
         $this->_encoder->endTag(); // Result
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
# Skip missing messages in Find results

## Summary

Prevents a single unavailable mailbox hit from failing the entire EAS 16.0 Find response with HTTP 500.

## Problem

Find searches IMAP and then fetches each hit via `itemOperationsFetchMailbox()` to build preview properties (Subject, From, Preview, etc.). If one message is no longer available when fetched — deleted, moved, or present only in a stale search cache entry — `getMessage()` throws `Horde_Exception_NotFound` (`Nicht gefunden`). That exception propagated out of `_encodeResult()` and aborted the whole Find response, even when other hits were valid.

Observed in production: two ESET messages encoded successfully; a third stale UID caused HTTP 500 and a truncated WBXML buffer.

## Solution

- Fetch the message **before** opening the `Find:Result` WBXML element.
- Catch `Horde_Exception_NotFound`, log at info level, and skip that hit.
- Return a boolean from `_encodeResult()`; only successfully encoded hits count toward `Find:Range`.

`Find:Total` still reflects the IMAP search count; `Find:Range` reflects the number of results actually returned.

## Files changed

- `lib/Horde/ActiveSync/Request/Find.php`

## Test plan

- [ ] Search for a term with known matches — results return status 1, no HTTP 500
- [ ] If reproducible: delete/move a message that matches the query, search again — remaining hits still returned; log contains `Find: message … no longer available, skipping result.`
- [ ] `Find:Range` matches the number of encoded results when some hits are skipped

## Suggested commit message

```
fix(activesync): skip missing messages in Find results

Fetch each hit before encoding and ignore Horde_Exception_NotFound
so a deleted or stale search result no longer aborts the entire
Find response with HTTP 500.
```

## Author

Torben Dannhauer <torben@dannhauer.de>
