### PR TITLE
fix(activesync): return object-not-found for deleted ItemOperations f…

### DIFF
--- a/lib/Horde/ActiveSync/Request/ItemOperations.php
+++ b/lib/Horde/ActiveSync/Request/ItemOperations.php
@@ -61,6 +61,7 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
     public const STATUS_PROTERR         = 2;
     public const STATUS_SERVERERR       = 3;
     // 4 - 13 are Document library related.
+    public const STATUS_OBJECTNOTFOUND  = 6;
     public const STATUS_ATTINVALID      = 15;
     public const STATUS_POLICYERR       = 16;
     public const STATUS_PARTSUCCESS     = 17;
@@ -206,6 +207,8 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
                             // they are not documentLibrary items. The backend
                             // needs to be able to identify where to get the
                             // item from based solely on the filereference.
+                            $this->_statusCode = self::STATUS_SUCCESS;
+                            $msg = null;
                             $this->_encoder->startTag(self::ITEMOPERATIONS_FETCH);
                             if (isset($value['airsyncbasefilereference'])) {
                                 // filereference is already in the backend serverid format
@@ -224,61 +227,49 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
                                 $this->_encoder->content($value['airsyncbasefilereference']);
                                 $this->_encoder->endTag();
                             } elseif (isset($value['searchlongid'])) {
+                                $msg = $this->_fetchMailboxMessage(
+                                    $value,
+                                    $collections,
+                                    $mimesupport,
+                                    'searchlongid'
+                                );
                                 $this->_outputStatus();
-                                $this->_encoder->startTag(Horde_ActiveSync_Request_Search::SEARCH_LONGID);
-                                $this->_encoder->content($value['searchlongid']);
-                                $this->_encoder->endTag();
-                                $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
-                                $this->_encoder->content('Email');
-                                $this->_encoder->endTag();
-                                $msg = $this->_driver->itemOperationsFetchMailbox($value['searchlongid'], $value['bodyprefs'], $mimesupport);
-                            } else {
-                                $this->_outputStatus();
-                                if (isset($value['folderid']) && isset($value['serverentryid'])) {
-                                    $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERID);
-                                    $this->_encoder->content($value['folderid']);
+                                if ($this->_statusCode == self::STATUS_SUCCESS && $msg) {
+                                    $this->_encoder->startTag(Horde_ActiveSync_Request_Search::SEARCH_LONGID);
+                                    $this->_encoder->content($value['searchlongid']);
                                     $this->_encoder->endTag();
-
-                                    $this->_encoder->startTag(Horde_ActiveSync::SYNC_SERVERENTRYID);
-                                    $this->_encoder->content($value['serverentryid']);
-                                    $this->_encoder->endTag();
-
                                     $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
                                     $this->_encoder->content('Email');
                                     $this->_encoder->endTag();
+                                }
+                            } else {
+                                if (isset($value['folderid']) && isset($value['serverentryid'])) {
+                                    $msg = $this->_fetchMailboxMessage(
+                                        $value,
+                                        $collections,
+                                        $mimesupport,
+                                        'folder'
+                                    );
+                                    $this->_outputStatus();
+                                    if ($this->_statusCode == self::STATUS_SUCCESS && $msg) {
+                                        $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERID);
+                                        $this->_encoder->content($value['folderid']);
+                                        $this->_encoder->endTag();
 
-                                    $longid = $this->_resolveFetchLongId($value);
-                                    if ($longid) {
-                                        $msg = $this->_driver->itemOperationsFetchMailbox(
-                                            $longid,
-                                            $value['bodyprefs'],
-                                            $mimesupport
-                                        );
-                                    } else {
-                                        try {
-                                            $mailbox = $collections->getBackendIdForFolderUid($value['folderid']);
-                                        } catch (Horde_ActiveSync_Exception_FolderGone $e) {
-                                            $this->_logger->err(sprintf(
-                                                'ItemOperations fetch: folder %s not in cache for UID %s.',
-                                                $value['folderid'],
-                                                $value['serverentryid']
-                                            ));
-                                            $this->_statusCode = self::STATUS_SERVERERR;
-                                            $mailbox = null;
-                                        }
-                                        if ($this->_statusCode == self::STATUS_SUCCESS) {
-                                            $msg = $this->_driver->fetch(
-                                                $mailbox,
-                                                $value['serverentryid'],
-                                                [
-                                                    'bodyprefs' => $value['bodyprefs'],
-                                                    'mimesupport' => $mimesupport]
-                                            );
-                                        }
+                                        $this->_encoder->startTag(Horde_ActiveSync::SYNC_SERVERENTRYID);
+                                        $this->_encoder->content($value['serverentryid']);
+                                        $this->_encoder->endTag();
+
+                                        $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
+                                        $this->_encoder->content('Email');
+                                        $this->_encoder->endTag();
                                     }
+                                } else {
+                                    $this->_statusCode = self::STATUS_PROTERR;
+                                    $this->_outputStatus();
                                 }
                             }
-                            if ($this->_statusCode == self::STATUS_SUCCESS) {
+                            if ($this->_statusCode == self::STATUS_SUCCESS && $msg) {
                                 $this->_encoder->startTag(self::ITEMOPERATIONS_PROPERTIES);
                                 $msg->encodeStream($this->_encoder);
                                 $this->_encoder->endTag();
@@ -355,6 +346,84 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
         return $this->_encoder->multipart
             ? 'application/vnd.ms-sync.multipart'
             : 'application/vnd.ms-sync.wbxml';
+    }
+
+    /**
+     * Fetch a mailbox message for ItemOperations.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param array  $value        Parsed ItemOperations fetch request.
+     * @param Horde_ActiveSync_Collections $collections  Folder cache.
+     * @param integer $mimesupport MIME support flag.
+     * @param string $mode         Either "searchlongid" or "folder".
+     *
+     * @return Horde_ActiveSync_Message_Base|null  Message or null on failure.
+     */
+    protected function _fetchMailboxMessage(
+        array $value,
+        Horde_ActiveSync_Collections $collections,
+        $mimesupport,
+        string $mode
+    ) {
+        $opts = [
+            'bodyprefs' => $value['bodyprefs'] ?? [],
+            'mimesupport' => $mimesupport,
+        ];
+
+        try {
+            if ($mode === 'searchlongid') {
+                return $this->_driver->itemOperationsFetchMailbox(
+                    $value['searchlongid'],
+                    $opts['bodyprefs'],
+                    $mimesupport
+                );
+            }
+
+            $longid = $this->_resolveFetchLongId($value);
+            if ($longid) {
+                return $this->_driver->itemOperationsFetchMailbox(
+                    $longid,
+                    $opts['bodyprefs'],
+                    $mimesupport
+                );
+            }
+
+            $folderid = $value['folderid'];
+            if ($folderid !== '' && $folderid[0] === 'M') {
+                $this->_logger->info(sprintf(
+                    'ItemOperations fetch: message UID %s not found for virtual folder %s.',
+                    $value['serverentryid'],
+                    $folderid
+                ));
+                $this->_statusCode = self::STATUS_OBJECTNOTFOUND;
+                return null;
+            }
+
+            $mailbox = $collections->getBackendIdForFolderUid($folderid);
+
+            return $this->_driver->fetch(
+                $mailbox,
+                $value['serverentryid'],
+                $opts
+            );
+        } catch (Horde_ActiveSync_Exception_FolderGone $e) {
+            $this->_logger->err(sprintf(
+                'ItemOperations fetch: folder %s not in cache for UID %s.',
+                $value['folderid'] ?? '',
+                $value['serverentryid'] ?? ''
+            ));
+            $this->_statusCode = self::STATUS_SERVERERR;
+            return null;
+        } catch (Horde_Exception_NotFound $e) {
+            $this->_logger->info(sprintf(
+                'ItemOperations fetch: message not found (folder=%s id=%s).',
+                $value['folderid'] ?? '',
+                $value['serverentryid'] ?? ($value['searchlongid'] ?? '')
+            ));
+            $this->_statusCode = self::STATUS_OBJECTNOTFOUND;
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
# fix(activesync): return object-not-found for deleted ItemOperations fetches

## Summary

Fix `ItemOperations:Fetch` for mailbox messages so deleted or missing items return **ItemOperations status 6 (Object not found)** instead of propagating `Horde_Exception_NotFound` as an HTTP 500.

This was observed when using **EAS 16.0 Find** on iOS: search hits could be opened successfully, but after deleting messages from the search results view the client issued follow-up `ItemOperations` fetches for stale IDs. The server logged `Nicht gefunden` and returned HTTP 500.

## Problem

For mailbox `ItemOperations:Fetch` requests identified by `FolderId`/`ServerEntryId` or `SearchLongId`, the handler:

1. Emitted **status 1 (Success)** before attempting the fetch
2. Wrote folder metadata (`FolderId`, `ServerEntryId`, `FolderType`) before verifying the message exists
3. Did not catch `Horde_Exception_NotFound` from `fetch()` / `getMessage()`

When a message had been deleted after appearing in Find results, the exception bubbled up and Horde returned **HTTP 500** while the device log showed a contradictory success status followed by `ERR: Nicht gefunden`.

A related case involved virtual Find folder IDs (`M<uid>` from iOS unified search): when `resolveLongIdForUid()` could not locate the message, the code fell through to `getBackendIdForFolderUid('M…')`, which raised `Horde_ActiveSync_Exception_FolderGone` and produced a server error instead of a clean per-fetch not-found response.

## Solution

- Add `STATUS_OBJECTNOTFOUND = 6` per MS-ASCMD ItemOperations status codes
- Introduce `_fetchMailboxMessage()` to centralize mailbox fetch logic with proper exception handling
- **Fetch first**, then emit status and metadata only on success
- Map `Horde_Exception_NotFound` → status **6**, log at INFO, skip properties encoding
- Map unresolved virtual `M<uid>` folder fetches → status **6** instead of folder-gone server error
- Reset `_statusCode` per mailbox fetch iteration (important when multiple fetches are batched)

## Changes

**`lib/Horde/ActiveSync/Request/ItemOperations.php`**

| Change | Detail |
|--------|--------|
| `STATUS_OBJECTNOTFOUND` | New constant (6) |
| `_fetchMailboxMessage()` | Shared fetch helper for `searchlongid` and `folderid`/`serverentryid` paths |
| Fetch ordering | Status and folder tags emitted only after a successful fetch |
| Error handling | `Horde_Exception_NotFound` → status 6; `Horde_ActiveSync_Exception_FolderGone` → status 3 |
| Virtual folder fallback | `M<uid>` folders with no resolvable long id → status 6 |

Unchanged: attachment (`FileReference`) and document library fetch paths.

## Test plan

- [ ] EAS 16.0 Find on iOS returns search hits
- [ ] Open a search result → message loads via `ItemOperations:Fetch` (status 1)
- [ ] Delete a message from the search results view → subsequent `ItemOperations:Fetch` returns **status 6**, no HTTP 500
- [ ] `horde.log` shows INFO `ItemOperations fetch: message not found …`, not `Returning HTTP 500`
- [ ] Device log shows per-fetch status 6 for stale hits, not `ERR: Nicht gefunden`
- [ ] Normal (non-search) `ItemOperations:Fetch` for existing messages still works
- [ ] `php -l` on modified file passes

## Related

Complements EAS 16.0 Find support, where `Find.php` already skips stale hits during result encoding. This change covers the separate client path where iOS re-fetches individual messages via `ItemOperations` after search.

## Commit message

```
fix(activesync): return object-not-found for deleted ItemOperations fetches

Catch Horde_Exception_NotFound when opening search hits that were removed
after Find, and respond with ItemOperations status 6 instead of HTTP 500.
Fetch mailbox messages before emitting success status and folder metadata.
```
