### PR TITLE
Feature/eas16.0 find

### DIFF
--- a/lib/Horde/ActiveSync/Request/ItemOperations.php
+++ b/lib/Horde/ActiveSync/Request/ItemOperations.php
@@ -244,6 +244,10 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
                                 }
                             } else {
                                 if (isset($value['folderid']) && isset($value['serverentryid'])) {
+                                    $folderType = $this->_getItemOperationsFolderType(
+                                        $collections,
+                                        $value['folderid']
+                                    );
                                     $msg = $this->_fetchMailboxMessage(
                                         $value,
                                         $collections,
@@ -261,7 +265,7 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
                                         $this->_encoder->endTag();
 
                                         $this->_encoder->startTag(Horde_ActiveSync::SYNC_FOLDERTYPE);
-                                        $this->_encoder->content('Email');
+                                        $this->_encoder->content($folderType);
                                         $this->_encoder->endTag();
                                     }
                                 } else {
@@ -346,6 +350,28 @@ class Horde_ActiveSync_Request_ItemOperations extends Horde_ActiveSync_Request_S
         return $this->_encoder->multipart
             ? 'application/vnd.ms-sync.multipart'
             : 'application/vnd.ms-sync.wbxml';
+    }
+
+    /**
+     * Folder type for an ItemOperations fetch (MS-ASCAL 3.1.4.3).
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_ActiveSync_Collections $collections
+     * @param string $folderid  Client folder/collection id.
+     *
+     * @return string  A Horde_ActiveSync::CLASS_* value.
+     */
+    protected function _getItemOperationsFolderType(
+        Horde_ActiveSync_Collections $collections,
+        $folderid
+    ) {
+        $class = $collections->getCollectionClass($folderid);
+        if ($class && $class !== 'RI') {
+            return $class;
+        }
+
+        return Horde_ActiveSync::CLASS_EMAIL;
     }
 
     /**

--- a/lib/Horde/ActiveSync/Request/Sync.php
+++ b/lib/Horde/ActiveSync/Request/Sync.php
@@ -974,7 +974,15 @@ class Horde_ActiveSync_Request_Sync extends Horde_ActiveSync_Request_SyncBase
                             // EAS 16.0 sends instanceid/serverid for exceptions.
                             if (!empty($instanceid)
                                 && $commandType == Horde_ActiveSync::SYNC_MODIFY) {
-                                $appdata->instanceid = $instanceid;
+                                try {
+                                    $appdata->instanceid = new Horde_Date($instanceid, 'UTC');
+                                } catch (Horde_Date_Exception $e) {
+                                    $this->_logger->err(sprintf(
+                                        'Invalid calendar InstanceId %s.',
+                                        $instanceid
+                                    ));
+                                    $appdata->instanceid = $instanceid;
+                                }
                             }
                             break;
                         case Horde_ActiveSync::CLASS_TASKS:


### PR DESCRIPTION
# fix(activesync): parse calendar InstanceId as Horde_Date on SYNC_MODIFY

## Summary

Parse `AirSyncBase:InstanceId` into a `Horde_Date` when handling **EAS 16.0** calendar `SYNC_MODIFY` requests for recurring-series exceptions, instead of passing the raw WBXML string to the backend.

Part of EAS 16.0 calendar instance/exception hardening (with companion PRs in **kronolith** and **mapi**).

## Problem

For EAS 16.0, iOS sends recurring-series exception edits as `SYNC_MODIFY` with `ServerEntryId` and `InstanceId` **outside** the `<Data>` block:

```xml
<Modify>
  <ServerEntryId>…</ServerEntryId>
  <InstanceId>20260615T070000Z</InstanceId>
  <Data>…</Data>
</Modify>
```

`Sync.php` read `InstanceId` via `getElementContent()` and assigned the raw string to `$appdata->instanceid`. `Horde_ActiveSync_Message_Appointment` maps `instanceid` as `TYPE_DATE` (`Horde_Date`) when decoded from WBXML inside `<Data>`, but the out-of-band InstanceId path bypassed that parsing.

Downstream in kronolith (`Event::_handleEas16Exception()`), InstanceId comparison and `Horde_Date` construction worked inconsistently depending on whether the value was a string or object.

## Solution

After decoding the appointment `<Data>`, parse the collected InstanceId string into `Horde_Date` (UTC) before assigning it to the message object. Invalid values are logged and left as the raw string for backward compatibility.

## Changes

**`lib/Horde/ActiveSync/Request/Sync.php`**

| Change | Detail |
|--------|--------|
| Calendar `SYNC_MODIFY` | `new Horde_Date($instanceid, 'UTC')` instead of raw string assignment |
| Error handling | Log invalid InstanceId, fall back to string on parse failure |

Unchanged: `SYNC_REMOVE` InstanceId handling (still passed as string to `calendar_delete`, which converts to `Horde_Date` in the connector).

## Related PRs

| Package | Change |
|---------|--------|
| **kronolith** | InstanceId helpers, exception modify/delete, master save, timezone fallback |
| **mapi** | Defensive guard in `_checkTransition()` for incomplete offset arrays |

## Test plan

- [ ] EAS 16.0 iPhone: modify a single instance of a recurring event → exception saved correctly
- [ ] EAS 16.0 iPhone: delete modified instance → `Deleted=1` exception exported
- [ ] EAS 16.0 iPhone: delete unmodified instance → `Deleted=1` exception exported
- [ ] Device log: `SYNC_MODIFY` with `InstanceId`, folder status 1, no HTTP 500
- [ ] `php -l` on modified file passes

## Commit message

```
fix(activesync): parse calendar InstanceId as Horde_Date on SYNC_MODIFY

Convert AirSyncBase InstanceId from raw WBXML string to Horde_Date when
assigning exception MODIFY payloads, matching kronolith EAS 16.0 handling.
```
