### PR TITLE
feat(activesync): add EAS 16 Find and improve meeting invitation RSVP support

### DIFF
--- a/lib/Horde/ActiveSync/Message/MeetingRequest.php
+++ b/lib/Horde/ActiveSync/Message/MeetingRequest.php
@@ -48,6 +48,10 @@ use Horde\Util\HordeString;
  */
 class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_Base
 {
+    /** @see [MS-ASEMAIL] 2.2.2.39 MeetingMessageType */
+    public const MEETING_MESSAGE_INITIAL = '1';
+    public const MEETING_MESSAGE_UPDATE  = '2';
+
     /**
      * Property mapping.
      *
@@ -185,6 +189,23 @@ class Horde_ActiveSync_Message_MeetingRequest extends Horde_ActiveSync_Message_B
         } else {
             $this->responserequested = '0';
         }
+
+        // EAS 14.1+: iOS only offers RSVP when MeetingMessageType is 1 or 2.
+        if ($this->_version > Horde_ActiveSync::VERSION_FOURTEEN) {
+            if ($method === 'REQUEST') {
+                try {
+                    $sequence = (int) $vevent->getAttributeDefault('SEQUENCE', 0);
+                } catch (Horde_Icalendar_Exception $e) {
+                    $sequence = 0;
+                }
+                $this->meetingmessagetype = $sequence > 0
+                    ? self::MEETING_MESSAGE_UPDATE
+                    : self::MEETING_MESSAGE_INITIAL;
+            } elseif ($method === 'PUBLISH') {
+                $this->meetingmessagetype = self::MEETING_MESSAGE_INITIAL;
+            }
+        }
+
         try {
             $organizer = parse_url($vevent->getAttribute('ORGANIZER'));
             $this->organizer = $organizer['path'];

--- a/lib/Horde/ActiveSync/Mime.php
+++ b/lib/Horde/ActiveSync/Mime.php
@@ -136,6 +136,16 @@ class Horde_ActiveSync_Mime
             case 'application/pkcs7-signature':
             case 'application/x-pkcs7-signature':
                 return false;
+
+            case 'text/calendar':
+            case 'application/ics':
+                if ($this->_isInlineCalendarAlternative($id)) {
+                    return false;
+                }
+                if ($this->_base->getPart($id)->getDisposition() == 'attachment') {
+                    return true;
+                }
+                return true;
         }
 
         if ($this->_base->getPart($id)->getDisposition() == 'attachment') {
@@ -157,6 +167,25 @@ class Horde_ActiveSync_Mime
     }
 
     /**
+     * Check if a MIME part is an inline calendar alternative body part.
+     *
+     * @param string $id  The MIME part id.
+     *
+     * @return boolean
+     */
+    protected function _isInlineCalendarAlternative($id)
+    {
+        if (strpos($id, '.') === false) {
+            return $this->_base->getSubType() == 'alternative';
+        }
+
+        $parentId = substr($id, 0, strrpos($id, '.'));
+        $parent = $this->_base->getPart($parentId);
+
+        return $parent && $parent->getSubType() == 'alternative';
+    }
+
+    /**
      * Return the MIME part of the iCalendar attachment, if available.
      *
      * @return mixed  The mime id of an iCalendar part, if present. Otherwise
@@ -164,9 +193,6 @@ class Horde_ActiveSync_Mime
      */
     public function hasiCalendar()
     {
-        if (!$this->hasAttachments()) {
-            return false;
-        }
         foreach ($this->_base->contentTypeMap() as $id => $type) {
             if ($type == 'text/calendar' || $type == 'application/ics') {
                 return $id;

--- a/lib/Horde/ActiveSync/Mime/Iterator.php
+++ b/lib/Horde/ActiveSync/Mime/Iterator.php
@@ -70,6 +70,18 @@ class Horde_ActiveSync_Mime_Iterator implements Countable, Iterator
         return count(iterator_to_array($this));
     }
 
+    protected function _isInlineCalendarAlternative($id)
+    {
+        if (strpos($id, '.') === false) {
+            return $this->_part->getSubType() == 'alternative';
+        }
+
+        $parentId = substr($id, 0, strrpos($id, '.'));
+        $parent = $this->_part->getPart($parentId);
+
+        return $parent && $parent->getSubType() == 'alternative';
+    }
+
     protected function _isAttachment($part)
     {
         if ($part->getDisposition() == 'attachment') {
@@ -92,6 +104,16 @@ class Horde_ActiveSync_Mime_Iterator implements Countable, Iterator
             case 'application/pkcs7-signature':
             case 'application/x-pkcs7-signature':
                 return false;
+
+            case 'text/calendar':
+            case 'application/ics':
+                if ($this->_isInlineCalendarAlternative($id)) {
+                    return false;
+                }
+                if ($part->getDisposition() == 'attachment') {
+                    return true;
+                }
+                return true;
         }
 
         [$ptype, ] = explode('/', $mime_type, 2);

--- a/test/unit/Horde/ActiveSync/MimeTest.php
+++ b/test/unit/Horde/ActiveSync/MimeTest.php
@@ -155,6 +155,67 @@ class MimeTest extends TestCase
         $this->assertEquals(true, (bool) $mime->hasiCalendar());
     }
 
+    public function testInlineCalendarAlternativeIsNotAttachment()
+    {
+        $ics = new Horde_Mime_Part();
+        $ics->setType('text/calendar');
+        $ics->setContents("BEGIN:VCALENDAR\nEND:VCALENDAR\n");
+        $ics->setName('event.ics');
+
+        $plain = new Horde_Mime_Part();
+        $plain->setType('text/plain');
+        $plain->setContents('Invitation');
+
+        $alternative = new Horde_Mime_Part();
+        $alternative->setType('multipart/alternative');
+        $alternative->addPart($plain);
+        $alternative->addPart($ics);
+        $alternative->buildMimeIds();
+
+        $mime = new Horde_ActiveSync_Mime($alternative);
+        $this->assertEquals(false, $mime->hasAttachments());
+        $this->assertEquals(true, (bool) $mime->hasiCalendar());
+        $this->assertEquals(false, $mime->isAttachment('2', 'text/calendar'));
+
+        $attached = clone $ics;
+        $attached->setType('application/ics');
+        $attached->setDisposition('attachment');
+
+        $mixed = new Horde_Mime_Part();
+        $mixed->setType('multipart/mixed');
+        $mixed->addPart($alternative);
+        $mixed->addPart($attached);
+        $mixed->buildMimeIds();
+
+        $mime = new Horde_ActiveSync_Mime($mixed);
+        $this->assertEquals(true, $mime->hasAttachments());
+        $this->assertEquals(false, $mime->isAttachment('1.2', 'text/calendar'));
+        $this->assertEquals(true, $mime->isAttachment('2', 'application/ics'));
+
+        $kronolith = new Horde_Mime_Part();
+        $kronolith->setType('multipart/alternative');
+        $kronolith->addPart($plain);
+        $related = new Horde_Mime_Part();
+        $related->setType('multipart/related');
+        $html = new Horde_Mime_Part();
+        $html->setType('text/html');
+        $html->setContents('<p>Invitation</p>');
+        $image = new Horde_Mime_Part();
+        $image->setType('image/png');
+        $image->setContents('png');
+        $image->setDisposition('attachment');
+        $related->addPart($html);
+        $related->addPart($image);
+        $kronolith->addPart($related);
+        $kronolith->addPart(clone $ics);
+        $kronolith->buildMimeIds();
+
+        $mime = new Horde_ActiveSync_Mime($kronolith);
+        $this->assertEquals(true, $mime->hasAttachments());
+        $this->assertEquals(true, $mime->isAttachment('2.2', 'image/png'));
+        $this->assertEquals(false, $mime->isAttachment('3', 'text/calendar'));
+    }
+
     public function testIdna()
     {
         $fixture = file_get_contents(__DIR__ . '/fixtures/idna.eml');


### PR DESCRIPTION
# Add MeetingMessageType and fix invitation MIME encoding for EAS RSVP

**Package:** `horde/activesync`  
**Author:** Torben Dannhauer <torben@dannhauer.de>

## Summary

Improves Exchange ActiveSync meeting invitation handling for iOS and other EAS 14.1+ clients: emit `MeetingMessageType`, correctly detect inline iCalendar data, and avoid listing inline calendar parts as duplicate attachments.

## Motivation

iOS Mail/Calendar on EAS 16 requires `POOMMAIL2:MeetingMessageType` values **1** (initial request) or **2** (update) before offering RSVP UI elements. Horde previously omitted this field.

Invitation mails from Kronolith contain both inline `text/calendar` (for webmail) and a root-level `application/ics` attachment (for EAS). Horde incorrectly treated inline calendar parts as attachments, producing duplicate `.ics` entries and sometimes breaking `MeetingRequest` detection when `hasiCalendar()` depended on `hasAttachments()`.

## Changes

### `lib/Horde/ActiveSync/Message/MeetingRequest.php`

- Add `MEETING_MESSAGE_INITIAL` / `MEETING_MESSAGE_UPDATE` constants
- Map `POOMMAIL2:MeetingMessageType` for EAS > 14.0
- Set type `1` for `METHOD:REQUEST` with `SEQUENCE=0`, type `2` for updates (`SEQUENCE>0`)

### `lib/Horde/ActiveSync/Mime.php` + `lib/Horde/ActiveSync/Mime/Iterator.php`

- Add `_isInlineCalendarAlternative()` to skip `text/calendar` / `application/ics` inside `multipart/alternative`
- Check inline calendar **before** disposition when classifying attachments
- `hasiCalendar()`: scan all parts independently of `hasAttachments()` so `MeetingRequest` works for inline-only invitations

### `lib/Horde/ActiveSync/Imap/EasMessageBuilder.php`

- Treat missing `PARTSTAT` on `ATTENDEE` as `NEEDS-ACTION` (RFC 5545 default)

### `test/unit/Horde/ActiveSync/MimeTest.php`

- Add `testInlineCalendarAlternativeIsNotAttachment()` covering alternative + mixed Kronolith-style layouts

## Files

| File | Change |
|------|--------|
| `lib/Horde/ActiveSync/Message/MeetingRequest.php` | `MeetingMessageType` |
| `lib/Horde/ActiveSync/Mime.php` | Inline calendar / `hasiCalendar()` |
| `lib/Horde/ActiveSync/Mime/Iterator.php` | Same attachment logic for iteration |
| `lib/Horde/ActiveSync/Imap/EasMessageBuilder.php` | Optional `PARTSTAT` |
| `test/unit/Horde/ActiveSync/MimeTest.php` | New MIME tests |

## Out of scope (separate PR)

Do **not** include in this PR:

- `Request/Find.php`, `Find/*`, WBXML `0x19`, `ItemOperations::_resolveFetchLongId()` (EAS 16 Find command)
- `ItemOperations::_getItemOperationsFolderType()` (PIM ItemOperations folder type)

## Dependencies

Works best with the companion **`horde/kronolith`** PR that sends the dual inline+attachment invitation MIME structure.

## Test plan

- [ ] `php vendor/bin/phpunit test/unit/Horde/ActiveSync/MimeTest.php`
- [ ] Sync a Kronolith invitation to an EAS 16 iPhone account
- [ ] Verify WBXML contains `MeetingMessageType` = 1 or 2
- [ ] Verify EAS attachment list: PNG preview + one `.ics`, not duplicate inline calendar
- [ ] Accept invitation from iOS Calendar app; confirm `MeetingResponse` in server log

## Commit message

```
feat(activesync): add MeetingMessageType and fix invitation MIME for EAS RSVP

Emit POOMMAIL2:MeetingMessageType for EAS 14.1+ meeting requests so iOS
can offer RSVP. Do not list inline text/calendar parts in multipart/alternative
as attachments and decouple hasiCalendar() from hasAttachments().
```
