### PR TITLE
feat(activesync): harden EAS 16.0 appointments

### DIFF
--- a/lib/Horde/ActiveSync/Message/Appointment.php
+++ b/lib/Horde/ActiveSync/Message/Appointment.php
@@ -319,13 +319,11 @@ class Horde_ActiveSync_Message_Appointment extends Horde_ActiveSync_Message_Base
         }
 
         // These values are not allowed in a EAS 16.0 command request.
-        // @todo - should we just wipe the values instead of failing the test?
         if ($this->_version == Horde_ActiveSync::VERSION_SIXTEEN) {
-            if (!empty($this->_properties['uid'])
-                || !empty($this->_properties['dtstamp'])
-                || !empty($this->_properties['organizername'])
-                || !empty($this->_properties['organizeremail'])) {
-                return false;
+            foreach (['uid', 'dtstamp', 'organizername', 'organizeremail'] as $property) {
+                if (!empty($this->_properties[$property])) {
+                    $this->_properties[$property] = false;
+                }
             }
         }
 
@@ -694,7 +692,11 @@ class Horde_ActiveSync_Message_Appointment extends Horde_ActiveSync_Message_Base
      */
     public function setRecurrence(Horde_Date_Recurrence $recurrence, $fdow = null)
     {
-        $r = Horde_ActiveSync::messageFactory('Recurrence');
+        $r = new Horde_ActiveSync_Message_Recurrence([
+            'logger' => $this->_logger,
+            'protocolversion' => $this->_version,
+            'device' => $this->_device,
+        ]);
 
         if ($this->_version >= Horde_ActiveSync::VERSION_FOURTEENONE) {
             $r->firstdayofweek = $fdow;

--- a/lib/Horde/ActiveSync/Message/Appointment.php
+++ b/lib/Horde/ActiveSync/Message/Appointment.php
@@ -321,7 +321,7 @@ class Horde_ActiveSync_Message_Appointment extends Horde_ActiveSync_Message_Base
         // These values are not allowed in a EAS 16.0 command request.
         if ($this->_version == Horde_ActiveSync::VERSION_SIXTEEN) {
             foreach (['uid', 'dtstamp', 'organizername', 'organizeremail'] as $property) {
-                if ($this->_properties[$property] !== false) {
+                if (isset($this->_properties[$property]) && $this->_properties[$property] !== false) {
                     $this->_properties[$property] = false;
                     unset($this->_exists[$property]);
                 }

--- a/lib/Horde/ActiveSync/Message/Appointment.php
+++ b/lib/Horde/ActiveSync/Message/Appointment.php
@@ -321,8 +321,9 @@ class Horde_ActiveSync_Message_Appointment extends Horde_ActiveSync_Message_Base
         // These values are not allowed in a EAS 16.0 command request.
         if ($this->_version == Horde_ActiveSync::VERSION_SIXTEEN) {
             foreach (['uid', 'dtstamp', 'organizername', 'organizeremail'] as $property) {
-                if (!empty($this->_properties[$property])) {
+                if ($this->_properties[$property] !== false) {
                     $this->_properties[$property] = false;
+                    unset($this->_exists[$property]);
                 }
             }
         }

--- a/lib/Horde/ActiveSync/Request/MeetingResponse.php
+++ b/lib/Horde/ActiveSync/Request/MeetingResponse.php
@@ -44,7 +44,7 @@ class Horde_ActiveSync_Request_MeetingResponse extends Horde_ActiveSync_Request_
     // 14.1
     public const MEETINGRESPONSE_INSTANCEID      = 'MeetingResponse:InstanceId';
 
-    // 16.0 @todo
+    // 16.0
     public const MEETINGRESPONSE_SENDRESPONSE    = 'MeetingResponse:SendResponse';
 
     // Response constants

--- a/test/unit/Horde/ActiveSync/AppointmentTest.php
+++ b/test/unit/Horde/ActiveSync/AppointmentTest.php
@@ -499,4 +499,25 @@ class AppointmentTest extends TestCase
         $this->assertEquals(true, $contact->isGhosted('body'));
     }
 
+    public function testEas16StripsForbiddenInboundFields()
+    {
+        $logger = new Horde_ActiveSync_Log_Logger(new Horde_Log_Handler_Null());
+        $message = new Horde_ActiveSync_Message_Appointment([
+            'logger' => $logger,
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $message->uid = 'client-uid-not-server';
+        $message->dtstamp = new Horde_Date('2026-06-16T10:00:00', 'UTC');
+        $message->organizername = 'Organizer';
+        $message->organizeremail = 'org@example.com';
+
+        $method = new \ReflectionMethod($message, '_validateDecodedValues');
+        $method->setAccessible(true);
+        $this->assertTrue($method->invoke($message));
+        $this->assertFalse($message->getProperty('uid'));
+        $this->assertFalse($message->getProperty('dtstamp'));
+        $this->assertFalse($message->getProperty('organizername'));
+        $this->assertFalse($message->getProperty('organizeremail'));
+    }
+
 }

--- a/test/unit/Horde/ActiveSync/AppointmentTest.php
+++ b/test/unit/Horde/ActiveSync/AppointmentTest.php
@@ -21,6 +21,7 @@ use Horde_ActiveSync_Message_Appointment;
 use Horde_Date;
 use Horde_ActiveSync_Device;
 use Horde_Date_Recurrence;
+use Horde_ActiveSync_Message_Recurrence;
 
 #[CoversNothing]
 class AppointmentTest extends TestCase
@@ -497,6 +498,38 @@ class AppointmentTest extends TestCase
         $contact->setSupported([Horde_ActiveSync::ALL_GHOSTED]);
         $this->assertEquals(true, $contact->isGhosted('subject'));
         $this->assertEquals(true, $contact->isGhosted('body'));
+    }
+
+    /**
+     * Regression test: setRecurrence() on an EAS 16.0 appointment must not
+     * throw an "unknown property" exception for firstdayofweek, and the
+     * resulting recurrence sub-message must expose the value correctly.
+     */
+    public function testSetRecurrenceEas16SetsFirstDayOfWeek()
+    {
+        $logger = new Horde_ActiveSync_Log_Logger(new Horde_Log_Handler_Null());
+        $appt = new Horde_ActiveSync_Message_Appointment([
+            'logger' => $logger,
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $start = new Horde_Date('2024-01-01T10:00:00', 'UTC');
+        $appt->starttime = $start;
+        $appt->endtime = new Horde_Date('2024-01-01T11:00:00', 'UTC');
+        $appt->setTimezone($start);
+
+        $recurrence = new Horde_Date_Recurrence('2024-01-01T10:00:00');
+        $recurrence->setRecurType(Horde_Date_Recurrence::RECUR_WEEKLY);
+        $recurrence->setRecurInterval(1);
+        $recurrence->setRecurOnDay(Horde_Date::MASK_MONDAY);
+
+        $fdow = Horde_ActiveSync_Message_Recurrence::FIRSTDAY_SUNDAY;
+
+        // Must not throw an exception (e.g. "unknown property firstdayofweek")
+        $appt->setRecurrence($recurrence, $fdow);
+
+        // The recurrence sub-message must have firstdayofweek set to the
+        // value we passed in.
+        $this->assertEquals($fdow, $appt->recurrence->firstdayofweek);
     }
 
     public function testEas16StripsForbiddenInboundFields()


### PR DESCRIPTION
# Pull request: ActiveSync EAS 16.0 library updates

## Conventional commit message

```
feat(activesync): harden EAS 16.0 appointments

Strip forbidden inbound appointment fields per MS-ASCAL 16.0, construct
Recurrence sub-messages with the appointment protocol version, and add unit
tests.
```

## PR title

`feat(activesync): harden EAS 16.0 appointments`

## Summary

- **EAS 16.0 appointment validation (C8):** `_validateDecodedValues()` strips forbidden inbound fields (`uid`, `dtstamp`, `organizername`, `organizeremail`) instead of rejecting the whole item, per MS-ASCAL.
- **`setRecurrence()` fix:** build `Horde_ActiveSync_Message_Recurrence` with the parent appointment’s `protocolversion` so properties such as `firstdayofweek` (14.1+) are defined when exporting recurring events at 16.0.
- **MeetingResponse:** remove stale 16.0 `@todo` comment (SendResponse constant is in use).

## Changed files

| File | Change |
|------|--------|
| `lib/Horde/ActiveSync/Message/Appointment.php` | 16.0 inbound field strip; recurrence sub-message protocol version |
| `lib/Horde/ActiveSync/Request/MeetingResponse.php` | Remove obsolete todo |
| `test/unit/Horde/ActiveSync/AppointmentTest.php` | `testEas16StripsForbiddenInboundFields()` |

## Related changes (other packages)

Calendar instance import/export and ClientUid/Location live in **horde/kronolith**. Draft send, `CHANGE_TYPE_DRAFT`, and driver `hide_exceptions` live in **horde/core**. This PR covers the activesync **library** layer only.

## Test plan

- [ ] `php vendor/bin/phpunit --bootstrap vendor/autoload.php vendor/horde/activesync/test/unit/Horde/ActiveSync/AppointmentTest.php --filter testEas16StripsForbiddenInboundFields`
- [ ] Full activesync unit suite: `cd vendor/horde/activesync && php ../../../vendor/bin/phpunit --bootstrap ../../../vendor/autoload.php`
- [ ] Export recurring calendar event at EAS 16.0 (with kronolith + core deployed) — no `firstdayofweek` Unknown property error
- [ ] Client MODIFY of existing appointment at 16.0 with forbidden top-level fields — item accepted and stripped fields ignored
